### PR TITLE
typo on tag url for learn-more

### DIFF
--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -480,7 +480,7 @@ export async function buildLearnMore(target, keywords) {
   items.forEach((keyword) => {
     const li = document.createElement('li');
     li.innerHTML = `
-      <a href="/tags/${encodeURIComponent(keyword)}" title="${keyword}" aria-label="${keyword}">
+      <a href="/tag/${encodeURIComponent(keyword)}/" title="${keyword}" aria-label="${keyword}">
         ${keyword}
       </a>
     `;


### PR DESCRIPTION
Test URLs:
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/news/computing/apple-mac-s-transition-from-intel-has-lured-influx-of-new-customers
- After: https://kunwarsaluja-patch-2--channelco-crn-com--hlxsites.hlx.page/news/computing/apple-mac-s-transition-from-intel-has-lured-influx-of-new-customers
