### PR TITLE
feat: integrate share-this into social-share block.

### DIFF
--- a/blocks/social-share/social-share.css
+++ b/blocks/social-share/social-share.css
@@ -1,43 +1,9 @@
-.social-share {
+.block.social-share {
   height: 32px;
-  display: flex;
-  align-items: center;
-  padding: .5rem 1rem;
-  border: 1px solid #8a8a8a;
+  border: 1px solid black;
+  padding: 0.5rem 2rem;
 }
 
-.social-share a {
-  width: 50px;
-  box-sizing: border-box;
-  border-radius: 4px;
-  border: none;
-  line-height: 32px;
-  margin-right: 8px;
-  padding: 0 10px;
-  text-align: center;
-  white-space: nowrap;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100%;
-}
-
-.social-share .social-share-linked-in {
-  background-color: #0077b5;
-}
-
-.social-share .social-share-facebook {
-  background-color: #4267B2;
-}
-
-.social-share .social-share-twitter {
-  background-color: #000;
-}
-
-.social-share .social-share-email {
-  background-color: #7d7d7d;
-}
-
-.social-share .social-share-this {
-  background-color: #95D03A;
+.social-share-buttons-container {
+  max-width: 300px;
 }

--- a/blocks/social-share/social-share.js
+++ b/blocks/social-share/social-share.js
@@ -3,22 +3,9 @@
  * @param {HTMLElement} block Default DOM structure for the block.
  */
 export default function decorate(block) {
-  // TODO: need to react to clicking share links.
   block.innerHTML = `
-    <a href="#" title="Share to LinkedIn" aria-label="Share to LinkedIn" class="social-share-linked-in">
-      <img src="https://platform-cdn.sharethis.com/img/linkedin.svg" alt="Share to LinkedIn" />
-    </a>
-    <a href="#" title="Share to Facebook" aria-label="Share to Facebook" class="social-share-facebook">
-      <img src="https://platform-cdn.sharethis.com/img/facebook.svg" alt="Share to Facebook" />
-    </a>
-    <a href="#" title="Share to Twitter" aria-label="Share to Twitter" class="social-share-twitter">
-      <img src="https://platform-cdn.sharethis.com/img/twitter.svg" alt="Share to Twitter" />
-    </a>
-    <a href="#" title="Share to Email" aria-label="Share to Email" class="social-share-email">
-      <img src="https://platform-cdn.sharethis.com/img/email.svg" alt="Share to Email" />
-    </a>
-    <a href="#" title="Share This" aria-label="Share This" class="social-share-this">
-      <img src="https://platform-cdn.sharethis.com/img/sharethis.svg" alt="Share This" />
-    </a>
+    <div class="social-share-buttons-container">
+      <div class="sharethis-inline-share-buttons"></div>
+    </div>
   `;
 }

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -101,8 +101,14 @@ function loadDelayedAds(main) {
   }
 }
 
+async function loadShareThis() {
+  loadScript('https://platform-api.sharethis.com/js/sharethis.js#property=6436d2b545aa460012e10320&product=sop');
+  return loadScript('https://buttons-config.sharethis.com/js/6436d2b545aa460012e10320.js', { async: '' });
+}
+
 await loadRightAdFragment();
 loadDelayedAds(document.querySelector('main'));
+loadShareThis();
 
 // Core Web Vitals RUM collection
 sampleRUM('cwv');


### PR DESCRIPTION
This PR replaces the `social-share` block placeholder buttons with a ShareThis integration.

As discussed in Slack, I did a PoC where I was able to add our own event listeners to the buttons. That way if the ShareThis analytics aren't enough, we could potentially send our own analytics somewhere else whenever a visitor clicks a button.

Fix #20 

Test URLs:
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/news/computing/apple-mac-s-transition-from-intel-has-lured-influx-of-new-customers
- After: https://issue-20--channelco-crn-com--hlxsites.hlx.page/news/computing/apple-mac-s-transition-from-intel-has-lured-influx-of-new-customers
