### PR TITLE
feat: dynamically build related articles

### DIFF
--- a/blocks/related-content/related-content.css
+++ b/blocks/related-content/related-content.css
@@ -3,7 +3,6 @@
   align-items: flex-start;
   border: 1px solid #494949;
   border-radius: 20px;
-  padding: 1rem;
   flex-direction: column;
 }
 
@@ -18,6 +17,7 @@
 
 .related-content .related-content-list {
   flex: 1;
+  padding: 1rem;
 }
 
 .related-content ul {
@@ -50,5 +50,10 @@
 @media (min-width: 576px) {
   .related-content > div > div {
     flex-direction: row;
+    gap: 2rem;
+  }
+
+  .related-content .related-content-list {
+    padding: 1rem 0;
   }
 }

--- a/blocks/related-content/related-content.js
+++ b/blocks/related-content/related-content.js
@@ -1,5 +1,4 @@
 import { decorateIcons } from '../../scripts/lib-franklin.js';
-import { getRecordsFromBlock } from '../../scripts/shared.js';
 
 /**
  * Modifies the block's DOM as necessary.
@@ -16,21 +15,9 @@ export default async function decorate(block) {
 
   const list = document.createElement('div');
   list.classList.add('related-content-list');
+  list.append(ul);
 
   target.append(icon, list);
 
   decorateIcons(block);
-
-  const articles = await getRecordsFromBlock(block);
-  const articleList = document.createElement('ul');
-  articles.forEach((article) => {
-    const articleItem = document.createElement('li');
-    articleItem.innerHTML = `
-      <a href="${article.path}" title="${article.title}" aria-label="${article.title}">
-        ${article.title}
-      </a>
-    `;
-    articleList.append(articleItem);
-  });
-  list.append(articleList);
 }

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -520,7 +520,6 @@ export async function buildRelatedContent(target, articlePaths) {
       </a>
     `;
     ul.append(item);
-    console.log(item);
   });
   const relatedContent = buildBlock('related-content', { elems: [ul] });
   target.append(relatedContent);
@@ -545,7 +544,7 @@ export async function buildSocialShare(insertAfter) {
 function buildKeywordLookup(keywords) {
   const map = {};
   parseKeywords(keywords)
-    .forEach((keyword) => map[keyword] = true);
+    .forEach((keyword) => { map[keyword] = true; });
   return map;
 }
 
@@ -578,7 +577,7 @@ export async function getRelatedArticles(keywords, relatedCount = 5) {
     const currRecordKeywords = parseKeywords(record.keywords);
     currRecordKeywords.forEach((keyword) => {
       if (lookup[keyword]) {
-        matchCount++;
+        matchCount += 1;
       }
     });
     if (matchCount > 0) {
@@ -595,7 +594,8 @@ export async function getRelatedArticles(keywords, relatedCount = 5) {
   related.sort((a, b) => {
     if (a.relevance > b.relevance) {
       return -1;
-    } else if (a.relevance < b.relevance) {
+    }
+    if (a.relevance < b.relevance) {
       return 1;
     }
 
@@ -603,9 +603,11 @@ export async function getRelatedArticles(keywords, relatedCount = 5) {
     const recordB = b.record;
     if (!recordA.publisheddate && !recordB.publisheddate) {
       return 0;
-    } else if (!recordA.publisheddate && recordB.publisheddate) {
+    }
+    if (!recordA.publisheddate && recordB.publisheddate) {
       return 1;
-    } else if (recordA.publisheddate && !recordB.publisheddate) {
+    }
+    if (recordA.publisheddate && !recordB.publisheddate) {
       return -1;
     }
 

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -506,17 +506,17 @@ export async function buildLearnMore(target, keywords) {
  * Dynamically creates a related content block based on a given list of
  * article paths, then appends the new block to a given element.
  * @param {HTMLElement} target Element to which related content block will be added.
- * @param {Array<string>} articlePaths List of full article paths to use as
+ * @param {Array<QueryIndexRecord>} articles List of articles to use as
  *  related items.
  * @returns {Promise} Resolves when the operation is complete.
  */
-export async function buildRelatedContent(target, articlePaths) {
+export async function buildRelatedContent(target, articles) {
   const ul = document.createElement('ul');
-  articlePaths.forEach((article) => {
+  articles.forEach((article) => {
     const item = document.createElement('li');
     item.innerHTML = `
-      <a href="${article}">
-        ${article}
+      <a href="${article.path}" title="${article.title}" aria-label="${article.title}">
+        ${article.title}
       </a>
     `;
     ul.append(item);

--- a/templates/article/article.js
+++ b/templates/article/article.js
@@ -57,6 +57,6 @@ export default async function loadTemplate(main) {
     }
   }
 
-  const related = await getRelatedArticles(article.keywords);
+  const related = await getRelatedArticles(article);
   await buildRelatedContent(heading.parentElement, related.map((relatedArticle) => `${window.location.protocol}//${window.location.host}${relatedArticle.path}`));
 }

--- a/templates/article/article.js
+++ b/templates/article/article.js
@@ -58,5 +58,5 @@ export default async function loadTemplate(main) {
   }
 
   const related = await getRelatedArticles(article);
-  await buildRelatedContent(heading.parentElement, related.map((relatedArticle) => `${window.location.protocol}//${window.location.host}${relatedArticle.path}`));
+  await buildRelatedContent(heading.parentElement, related);
 }

--- a/templates/article/article.js
+++ b/templates/article/article.js
@@ -58,5 +58,5 @@ export default async function loadTemplate(main) {
   }
 
   const related = await getRelatedArticles(article.keywords);
-  await buildRelatedContent(heading.parentElement, related.map((article) => `${window.location.protocol}//${window.location.host}${article.path}`));
+  await buildRelatedContent(heading.parentElement, related.map((relatedArticle) => `${window.location.protocol}//${window.location.host}${relatedArticle.path}`));
 }

--- a/templates/article/article.js
+++ b/templates/article/article.js
@@ -8,6 +8,7 @@ import {
   buildLearnMore,
   buildRelatedContent,
   buildSocialShare,
+  getRelatedArticles,
 } from '../../scripts/shared.js';
 
 /**
@@ -55,13 +56,7 @@ export default async function loadTemplate(main) {
       authorLink.classList.add('link-arrow');
     }
   }
-  // TODO: need to determine how to get related content. For now it will just
-  // link to a static list.
-  await buildRelatedContent(heading.parentElement, [
-    'https://main--channelco-crn-com--hlxsites.hlx.page/news/managed-services/painful-decision-slalom-consulting-layoffs-hit-900-workers',
-    'https://main--channelco-crn-com--hlxsites.hlx.page/news/internet-of-things/5-industrial-iot-solutions-that-are-solving-big-problems',
-    'https://main--channelco-crn-com--hlxsites.hlx.page/news/computing/apple-mac-s-transition-from-intel-has-lured-influx-of-new-customers',
-    'https://main--channelco-crn-com--hlxsites.hlx.page/news/computing/asus-starts-selling-nuc-mini-pcs-after-intel-exits-business',
-    'https://main--channelco-crn-com--hlxsites.hlx.page/news/computing/dell-s-moonshot-5-key-features-of-concept-luna',
-  ]);
+
+  const related = await getRelatedArticles(article.keywords);
+  await buildRelatedContent(heading.parentElement, related.map((article) => `${window.location.protocol}//${window.location.host}${article.path}`));
 }

--- a/templates/universal/universal.css
+++ b/templates/universal/universal.css
@@ -125,7 +125,7 @@ main .back-top-top-section-header {
     display: grid;
     gap: var(--padding-spacer-x);
     grid-template:
-      ". content ads ." / auto auto 330px auto;
+      ". content ads ." / auto 1fr 330px auto;
   }
 
   main .content-and-ads-container .content-section {


### PR DESCRIPTION
This is an initial implementation of dynamically retrieving related articles. At a high level, the algorithm will query the index and assign a "score" to each article based on how many of its keywords match the current article's keywords. If the score between two articles is the same, articles with newer publish dates are preferred.

After assigning scores, the list of articles is sorted in descending order by score, then the top 5 highest scoring articles are used as the related articles.

The block is authored using article URLs:

![Screenshot 2023-09-29 at 9 03 53 AM](https://github.com/hlxsites/channelco-crn-com/assets/5108740/37f3c166-4b2e-43d4-a027-cab507d7c208)

Rendered as follows:

![Screenshot 2023-09-28 at 8 50 42 AM](https://github.com/hlxsites/channelco-crn-com/assets/5108740/d556f878-b49e-4c49-8143-b3bf5273cb26)


There are some performance concerns that we may need to address when we have more article data:

* I'd imagine that this implementation won't scale. We're essentially querying and traversing the entire index, which will also be read into the browser's memory.
* Due to how heavy the operation is, it might be good to do this in the delayed phase.

Fix #19 

Test URLs:
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/news/internet-of-things/5-industrial-iot-solutions-that-are-solving-big-problems
- After: https://issue-19--channelco-crn-com--hlxsites.hlx.page/news/internet-of-things/5-industrial-iot-solutions-that-are-solving-big-problems
