### PR TITLE
fix: improve efficiency of to top link.

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -77,12 +77,7 @@ function createToTopSection() {
 
   const toTopHeader = document.createElement('h3');
   toTopHeader.className = 'back-top-top-section-header';
-
-  const toTopIcon = document.createElement('img');
-  toTopIcon.className = 'triangle-fill';
-  toTopIcon.src = '/styles/icons/triangle-fill.svg';
-  toTopHeader.appendChild(toTopIcon);
-  toTopHeader.appendChild(document.createTextNode(' TO TOP'));
+  toTopHeader.innerText = 'To Top';
 
   toTopLink.appendChild(toTopHeader);
   toTopContent.appendChild(toTopLink);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -294,7 +294,15 @@ main .divider {
   padding: 0;
   font-size: var(--heading-font-size-ms);
 }
- 
+
+main .back-top-top-section-header {
+  text-transform: uppercase;
+}
+
+main .back-top-top-section-header::before {
+  content: '▲';
+}
+
 @media (min-width: 576px) {
   main .section > div {
     max-width: 540px;


### PR DESCRIPTION
Small efficiency change for the "To Top" link to address this warning in the page analysis:

![Screenshot 2023-09-28 at 10 07 20 AM](https://github.com/hlxsites/channelco-crn-com/assets/5108740/e4a6a4a7-abe7-4bbf-bb76-eb4af2713407)

The change uses an ascii character for the "up" arrow image, which will eliminate the need to load an image, reduce the number of elements in the DOM slightly (which we also have a warning for), and makes the link more CSS-y.

Let me know your thoughts. Totally happy to continue using the image, just wanted to point this out as a different way of doing it.

Test URLs:
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/
- After: https://to-top-fix--channelco-crn-com--hlxsites.hlx.page/
