### PR TITLE
feat: add category template

### DIFF
--- a/blocks/category-navigation/category-navigation.css
+++ b/blocks/category-navigation/category-navigation.css
@@ -1,0 +1,1 @@
+/* styles here */

--- a/blocks/category-navigation/category-navigation.js
+++ b/blocks/category-navigation/category-navigation.js
@@ -1,0 +1,3 @@
+export default function decorate(block) {
+  block.innerHTML = 'category-navigation placeholder';
+}

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -265,6 +265,18 @@ export function getCategoryName(record) {
  * @property {string} lastModified Unix timestamp of the last time the index record was modified.
  */
 
+/**
+ * Determines whether a given record from the site's query index is an article.
+ * @param {QueryIndexRecord} record Record to test.
+ * @returns {boolean} True if the record is an article, false otherwise.
+ */
+export function isArticle(record) {
+  // the record is an article if its path starts with /news/, and its template is
+  // either empty or "article"
+  return (!record.template || String(record.template).toLowerCase() === 'article')
+    && String(record.path).startsWith('/news/');
+}
+
 let cachedIndex;
 /**
  * Queries the site's index and only includes those records that match a given filter.
@@ -305,6 +317,16 @@ export async function getRecordsByPath(paths) {
   const pathLookup = {};
   paths.forEach((path) => { pathLookup[path] = true; });
   return queryIndex((record) => !!pathLookup[record.path]);
+}
+
+/**
+ * Retrieves all articles in a given category.
+ * @param {string} categoryName Category whose articles should be retrieved.
+ * @returns {Promise<Array<QueryIndexRecord>>} Resolves with an array of matching
+ *  articles.
+ */
+export async function getArticlesByCategory(categoryName) {
+  return queryIndex((record) => record.category === categoryName && isArticle(record));
 }
 
 /**
@@ -582,18 +604,6 @@ function calculateScore(keywordLookup, record) {
 }
 
 /**
- * Determines whether a given record from the site's query index is an article.
- * @param {QueryIndexRecord} record Record to test.
- * @returns {boolean} True if the record is an article, false otherwise.
- */
-export function isArticle(record) {
-  // the record is an article if its path starts with /news/, and its template is
-  // either empty or "article"
-  return (!record.template || String(record.template).toLowerCase() === 'article')
-    && String(record.path).startsWith('/news/');
-}
-
-/**
  * @typedef QueryIndexRecordRelevance
  * @property {QueryIndexRecord} record Record from the query index to which
  *  the relevance score applies.
@@ -654,7 +664,7 @@ function compareRelevance(a, b) {
  * @returns {number} Returns -1 if b has a more recent date than a, 1 if a
  *  has a more recent date than b, or 0 if the two are the same.
  */
-function comparePublishDate(a, b) {
+export function comparePublishDate(a, b) {
   if (!a.publisheddate && !b.publisheddate) {
     // records are the same when neither has a publish date
     return 0;

--- a/templates/category/category.css
+++ b/templates/category/category.css
@@ -1,1 +1,16 @@
-/* nothing here */
+.category main h1 {
+  color: var(--link-color);
+}
+
+.category main .content-section > h2 {
+  color: var(--link-color);
+  text-transform: uppercase;
+}
+
+.category main .article-card-title a {
+  color: var(--text-color);
+}
+
+.category main .article-cards:not(.lead-article) .article-card {
+  border-bottom: 2px dotted var(--color-mid-grey);
+}

--- a/templates/category/category.js
+++ b/templates/category/category.js
@@ -1,1 +1,88 @@
-/* nothing here */
+import {
+  buildBlock,
+  decorateBlock,
+  loadBlock,
+} from '../../scripts/lib-franklin.js';
+import {
+  getArticlesByCategory,
+  getRecordByPath,
+  comparePublishDate,
+} from '../../scripts/shared.js';
+
+function appendElementBeforeLast(target, last, toAppend) {
+  if (last) {
+    target.insertBefore(toAppend, last);
+  } else {
+    target.append(toAppend);
+  }
+}
+
+function buildArticleCards(articles) {
+  const ul = document.createElement('ul');
+  articles.forEach((article) => {
+    const li = document.createElement('li');
+    const articleUrl = `${window.location.protocol}//${window.location.host}${article.path}`;
+    li.innerHTML = `
+      <a href="${articleUrl}" title="${article.title}" aria-label="${article.title}">
+          ${articleUrl}
+      </a>
+    `;
+    ul.append(li);
+  });
+
+  return buildBlock('article-cards', { elems: [ul] });
+}
+
+/**
+ * Modifies the DOM with additional elements required to display a category page.
+ * @param {HTMLElement} main The page's main element.
+ */
+export default async function decorate(main) {
+  const category = await getRecordByPath(window.location.pathname);
+  if (!category) {
+    return;
+  }
+  let lastElement;
+  if (main.children.length > 0) {
+    lastElement = main.children.item(0);
+  }
+
+  const h1 = document.createElement('h1');
+  h1.innerText = category.title;
+  appendElementBeforeLast(main, lastElement, h1);
+
+  const tag = buildBlock('tag', { elems: [] });
+  appendElementBeforeLast(main, lastElement, tag);
+  decorateBlock(tag);
+  await loadBlock(tag);
+
+  const articles = await getArticlesByCategory(category.title);
+  articles.sort(comparePublishDate);
+
+  const leadCards = buildArticleCards(articles.slice(0, 5));
+  leadCards.classList.add('lead-article');
+  appendElementBeforeLast(main, lastElement, leadCards);
+  decorateBlock(leadCards);
+  await loadBlock(leadCards);
+
+  const newsLinkText = `${category.title} News`;
+  const newsLink = document.createElement('a');
+  newsLink.title = newsLinkText;
+  newsLink.ariaLabel = newsLinkText;
+  newsLink.classList.add('link-arrow');
+  newsLink.innerText = newsLinkText;
+
+  const newsHeading = document.createElement('h2');
+  newsHeading.append(newsLink);
+  appendElementBeforeLast(main, lastElement, newsHeading);
+
+  const cards = buildArticleCards(articles.slice(5, 13));
+  appendElementBeforeLast(main, lastElement, cards);
+  decorateBlock(cards);
+  await loadBlock(cards);
+
+  const categoryNavigation = buildBlock('category-navigation', { elems: [] });
+  main.append(categoryNavigation);
+  decorateBlock(categoryNavigation);
+  await loadBlock(categoryNavigation);
+}


### PR DESCRIPTION
Implements the category template, which autoblocks several elements on category pages. The template will retrieve all of a category's articles, then use the first 5 in the "lead article" section, and the next 8 as additional article cards on the page.

There are a couple of placeholder blocks, which I added issues to implement.

Fix #39 

Test URLs:
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/news/computing/
- After: https://issue-39--channelco-crn-com--hlxsites.hlx.page/news/computing/
