### PR TITLE
feat: implement company template

### DIFF
--- a/blocks/article-cards/article-cards.js
+++ b/blocks/article-cards/article-cards.js
@@ -1,9 +1,6 @@
 import {
-  getCategoryName,
-  getCategoryPath,
-  createOptimizedPicture,
   getRecordsFromBlock,
-  buildArticleAuthor,
+  buildArticleCardsContent,
 } from '../../scripts/shared.js';
 
 /**
@@ -11,6 +8,13 @@ import {
  * @param {HTMLElement} block The block's element on the page.
  */
 export default async function decorate(block) {
+  // only attempt to decorate the block if it consists of a list of
+  // URLs
+  const ul = block.querySelector('ul');
+  if (!ul) {
+    return;
+  }
+
   // retrieve article information for all specified article urls
   const articles = await getRecordsFromBlock(block);
 
@@ -19,53 +23,5 @@ export default async function decorate(block) {
     return;
   }
 
-  const addlArticleContainer = document.createElement('div');
-  addlArticleContainer.classList.add('sub-article');
-  // add article cards for each article
-  articles.forEach((article, index) => {
-    const cardDiv = document.createElement('div');
-    cardDiv.classList.add('article-card');
-
-    const category = document.createElement('h3');
-    category.classList.add('article-card-category');
-    const categoryName = getCategoryName(article);
-    category.innerHTML = `
-      <a href="${getCategoryPath(article.path)}" class="link-arrow" aria-label="${categoryName}">${categoryName}</a>
-    `;
-
-    const title = document.createElement('h5');
-    title.classList.add('article-card-title');
-    title.innerHTML = `
-      <a href="${article.path}" class="uncolored-link" aria-label="${article.title}">${article.title}</a>
-    `;
-
-    const author = buildArticleAuthor(article);
-    const description = document.createElement('p');
-    description.classList.add('article-card-description');
-    description.innerText = article.description;
-
-    const infoDiv = document.createElement('div');
-    infoDiv.append(category);
-    infoDiv.append(title);
-    infoDiv.append(author);
-    infoDiv.append(description);
-
-    const articlePictureLink = document.createElement('a');
-    articlePictureLink.href = article.path;
-    articlePictureLink.setAttribute('aria-label', article.title);
-    const articlePicture = createOptimizedPicture(article.image, article.title, index === 0);
-    articlePictureLink.append(articlePicture);
-    const articleImage = articlePicture.querySelector('img');
-    articleImage.title = article.title;
-    cardDiv.append(articlePictureLink);
-    cardDiv.append(infoDiv);
-
-    if (index > 0) {
-      addlArticleContainer.append(cardDiv);
-    } else {
-      cardDiv.classList.add('featured-article');
-      blockTarget.append(cardDiv);
-    }
-  });
-  blockTarget.append(addlArticleContainer);
+  await buildArticleCardsContent(articles, blockTarget);
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -14,7 +14,7 @@ import { decorateMain } from './shared.js';
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 
-const TEMPLATE_LIST = ['category', 'article', 'author'];
+const TEMPLATE_LIST = ['category', 'article', 'author', 'company'];
 
 /**
  * load fonts.css and set a session storage flag

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -753,6 +753,66 @@ export async function getRelatedArticles(article, relatedCount = 5) {
 }
 
 /**
+ * Builds and adds the DOM structure for the article-cards block based on a list
+ * of articles.
+ * @param {Array<QueryIndexRecord>} articles Records from which article cards
+ *  will be built.
+ * @param {HTMLElement} target Element to which the block content will be
+ *  added.
+ */
+export function buildArticleCardsContent(articles, target) {
+  const addlArticleContainer = document.createElement('div');
+  addlArticleContainer.classList.add('sub-article');
+  // add article cards for each article
+  articles.forEach((article, index) => {
+    const cardDiv = document.createElement('div');
+    cardDiv.classList.add('article-card');
+
+    const category = document.createElement('h3');
+    category.classList.add('article-card-category');
+    const categoryName = getCategoryName(article);
+    category.innerHTML = `
+      <a href="${getCategoryPath(article.path)}" class="link-arrow" aria-label="${categoryName}">${categoryName}</a>
+    `;
+
+    const title = document.createElement('h5');
+    title.classList.add('article-card-title');
+    title.innerHTML = `
+      <a href="${article.path}" class="uncolored-link" aria-label="${article.title}">${article.title}</a>
+    `;
+
+    const author = buildArticleAuthor(article);
+    const description = document.createElement('p');
+    description.classList.add('article-card-description');
+    description.innerText = article.description;
+
+    const infoDiv = document.createElement('div');
+    infoDiv.append(category);
+    infoDiv.append(title);
+    infoDiv.append(author);
+    infoDiv.append(description);
+
+    const articlePictureLink = document.createElement('a');
+    articlePictureLink.href = article.path;
+    articlePictureLink.setAttribute('aria-label', article.title);
+    const articlePicture = createOptimizedPicture(article.image, article.title, index === 0);
+    articlePictureLink.append(articlePicture);
+    const articleImage = articlePicture.querySelector('img');
+    articleImage.title = article.title;
+    cardDiv.append(articlePictureLink);
+    cardDiv.append(infoDiv);
+
+    if (index > 0) {
+      addlArticleContainer.append(cardDiv);
+    } else {
+      cardDiv.classList.add('featured-article');
+      target.append(cardDiv);
+    }
+  });
+  target.append(addlArticleContainer);
+}
+
+/**
  * Builds an article-cards block from a list of articles, and adds the
  * block to the DOM.
  * @param {Array<QueryIndexRecord>} articles Records from which article cards
@@ -762,22 +822,13 @@ export async function getRelatedArticles(article, relatedCount = 5) {
  * @returns {Promise} Resolves when the block is complete.
  */
 export async function buildArticleCardsBlock(articles, addBlockToDom) {
-  const ul = document.createElement('ul');
-  articles.forEach((article) => {
-    const li = document.createElement('li');
-    const articleUrl = `${window.location.protocol}//${window.location.host}${article.path}`;
-    li.innerHTML = `
-      <a href="${articleUrl}" title="${article.title}" aria-label="${article.title}">
-        ${articleUrl}
-      </a>
-    `;
-    ul.append(li);
-  });
-
-  const cards = buildBlock('article-cards', { elems: [ul] });
-  addBlockToDom(cards);
-  decorateBlock(cards);
-  await loadBlock(cards);
+  const block = document.createElement('div');
+  block.classList.add('article-cards', 'block');
+  block.setAttribute('data-block-name', 'article-cards');
+  block.innerHTML = '<div><div></div></div>';
+  await buildArticleCardsContent(articles, block.children.item(0).children.item(0));
+  addBlockToDom(block);
+  loadBlock(block);
 }
 
 /**

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -259,9 +259,9 @@ export function getCategoryName(record) {
  * @property {string} authordescription Bio information for the record's author.
  * @property {string} publisheddate Full, human-readable date when the record was published.
  * @property {string} keywords Comma-separated list of keywords associated with the index record.
- * @property {string} company-names Comma-separated list of companies to which the index record
+ * @property {string} companynames Comma-separated list of companies to which the index record
  *  applies.
- * @property {string} company-webpages Comma-separated list of websites for the index's companies.
+ * @property {string} companywebpages Comma-separated list of websites for the index's companies.
  * @property {string} lastModified Unix timestamp of the last time the index record was modified.
  */
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -160,7 +160,7 @@ a:hover {
   text-decoration: none;
 }
 
-a.link-arrow::after {
+.link-arrow::after {
   content: '▶';
   display: inline-block;
   margin-left: .5rem;

--- a/templates/category/category.css
+++ b/templates/category/category.css
@@ -1,10 +1,13 @@
 .category main h1 {
   color: var(--link-color);
+  margin-top: 0;
+  padding-top: 0;
 }
 
-.category main .content-section > h2 {
+.category main .content-section > a > h2 {
   color: var(--link-color);
   text-transform: uppercase;
+  display: inline-block;
 }
 
 .category main .article-card-title a {

--- a/templates/category/category.js
+++ b/templates/category/category.js
@@ -31,6 +31,6 @@ export default async function decorate(main) {
   const tag = buildBlock('tag', { elems: [] });
   main.insertBefore(tag, lastElement);
   decorateBlock(tag);
-  await loadBlock(tag);
-  await createTemplateWithArticles(main, `${category.title} News`, articles, lastElement);
+  loadBlock(tag);
+  createTemplateWithArticles(main, `${category.title} News`, articles, lastElement);
 }

--- a/templates/category/category.js
+++ b/templates/category/category.js
@@ -7,16 +7,8 @@ import {
   getArticlesByCategory,
   getRecordByPath,
   comparePublishDate,
-  buildArticleCardsBlock,
+  createTemplateWithArticles,
 } from '../../scripts/shared.js';
-
-function appendElementBeforeLast(target, last, toAppend) {
-  if (last) {
-    target.insertBefore(toAppend, last);
-  } else {
-    target.append(toAppend);
-  }
-}
 
 /**
  * Modifies the DOM with additional elements required to display a category page.
@@ -27,45 +19,18 @@ export default async function decorate(main) {
   if (!category) {
     return;
   }
-  let lastElement;
-  if (main.children.length > 0) {
-    lastElement = main.children.item(0);
-  }
-
-  const h1 = document.createElement('h1');
-  h1.innerText = category.title;
-  appendElementBeforeLast(main, lastElement, h1);
-
-  const tag = buildBlock('tag', { elems: [] });
-  appendElementBeforeLast(main, lastElement, tag);
-  decorateBlock(tag);
-  await loadBlock(tag);
 
   const articles = await getArticlesByCategory(category.title);
   articles.sort(comparePublishDate);
 
-  buildArticleCardsBlock(articles.slice(0, 5), (leadCards) => {
-    leadCards.classList.add('lead-article');
-    appendElementBeforeLast(main, lastElement, leadCards);
-  });
+  const lastElement = main.children.length ? main.children.item(main.children.length - 1) : null;
+  const h1 = document.createElement('h1');
+  h1.innerText = category.title;
+  main.insertBefore(h1, lastElement);
 
-  const newsLinkText = `${category.title} News`;
-  const newsLink = document.createElement('a');
-  newsLink.title = newsLinkText;
-  newsLink.ariaLabel = newsLinkText;
-  newsLink.classList.add('link-arrow');
-  newsLink.innerText = newsLinkText;
-
-  const newsHeading = document.createElement('h2');
-  newsHeading.append(newsLink);
-  appendElementBeforeLast(main, lastElement, newsHeading);
-
-  buildArticleCardsBlock(articles.slice(5, 13), (cards) => {
-    appendElementBeforeLast(main, lastElement, cards);
-  });
-
-  const categoryNavigation = buildBlock('category-navigation', { elems: [] });
-  main.append(categoryNavigation);
-  decorateBlock(categoryNavigation);
-  await loadBlock(categoryNavigation);
+  const tag = buildBlock('tag', { elems: [] });
+  main.insertBefore(tag, lastElement);
+  decorateBlock(tag);
+  await loadBlock(tag);
+  await createTemplateWithArticles(main, `${category.title} News`, articles, lastElement);
 }

--- a/templates/company/company.css
+++ b/templates/company/company.css
@@ -1,0 +1,21 @@
+.company main h1 {
+  color: var(--link-color);
+  margin-top: 0;
+  padding-top: 0;
+  padding-bottom: 2rem;
+  border-bottom: 2px solid #c5c5c5;
+}
+
+.company main .content-section > h2,
+.company main .content-section > a > h2 {
+  color: var(--link-color);
+  text-transform: uppercase;
+}
+
+.company main .content-section > a > h2 {
+  display: inline-block;
+}
+
+.company main .article-card-title a {
+  color: var(--text-color);
+}

--- a/templates/company/company.js
+++ b/templates/company/company.js
@@ -17,8 +17,9 @@ export default async function decorate(main) {
     return;
   }
 
-  const companyName = company['company-names'];
-  const articles = await queryIndex((record) => isArticle(record) && commaSeparatedListContains(record['company-names'], companyName));
+  const companyName = company.companynames;
+  const articles = await queryIndex((record) => isArticle(record)
+    && commaSeparatedListContains(record.companynames, companyName));
   articles.sort(comparePublishDate);
 
   const lastElement = main.children.length ? main.children.item(main.children.length - 1) : null;

--- a/templates/company/company.js
+++ b/templates/company/company.js
@@ -1,0 +1,35 @@
+import {
+  getRecordByPath,
+  comparePublishDate,
+  createTemplateWithArticles,
+  queryIndex,
+  isArticle,
+  commaSeparatedListContains,
+} from '../../scripts/shared.js';
+
+/**
+ * Modifies the DOM as needed for the template.
+ * @param {HTMLElement} main The page's main element.
+ */
+export default async function decorate(main) {
+  const company = await getRecordByPath(window.location.pathname);
+  if (!company) {
+    return;
+  }
+
+  const companyName = company['company-names'];
+  const articles = await queryIndex((record) => isArticle(record) && commaSeparatedListContains(record['company-names'], companyName));
+  articles.sort(comparePublishDate);
+
+  const lastElement = main.children.length ? main.children.item(main.children.length - 1) : null;
+  const h1 = document.createElement('h1');
+  h1.innerText = companyName;
+  main.insertBefore(h1, lastElement);
+
+  const h2 = document.createElement('h2');
+  h2.classList.add('link-arrow');
+  h2.innerText = `News About ${companyName}`;
+  main.insertBefore(h2, lastElement);
+
+  await createTemplateWithArticles(main, 'More News', articles, lastElement);
+}


### PR DESCRIPTION
Moves some logic from the category template into the shared code so that the same format can be reused in multiple templates.

The page itself isn't very exciting right now since we don't have any company data yet, but all the functionality is there.

Fix #86 

Test URLs:
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/news/computing/
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/news/google-dwp
- After: https://issue-86--channelco-crn-com--hlxsites.hlx.page/news/computing/
- After: https://issue-86--channelco-crn-com--hlxsites.hlx.page/news/google-dwp
