### PR TITLE
feat: add eager, lazy, and delayed phases to templates.

### DIFF
--- a/blocks/news-slider/news-slider.js
+++ b/blocks/news-slider/news-slider.js
@@ -161,7 +161,7 @@ export default function decorate(block) {
       link.className = 'eyebrow-link';
       link.textContent = item.textContent;
 
-      link.addEventListener('click', function (event) {
+      link.addEventListener('click', (event) => {
         event.preventDefault();
         document.querySelectorAll('.eyebrow-link').forEach((el) => {
           el.classList.remove('active-tab');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -32,10 +32,7 @@ async function loadFonts() {
 
 /**
  * @typedef Template
- * @property {function} [default] Default export of the template, which will be called in the lazy
- *  phase. Expects a single argument: the document's <main> HTMLElement.
- * @property {function} [loadLazy] If provided, will be called in the lazy phase. If both a default
- *  export and loadLazy function are provided, only the default export will be called. Expects a
+ * @property {function} [loadLazy] If provided, will be called in the lazy phase. Expects a
  *  single argument: the document's <main> HTMLElement.
  * @property {function} [loadEager] If provided, will be called in the eager phase. Expects a single
  *  argument: the document's <main> HTMLElement.
@@ -70,9 +67,7 @@ async function loadEagerTemplate(toLoad, main) {
  */
 async function loadLazyTemplate(toLoad, main) {
   if (toLoad) {
-    if (toLoad.default) {
-      await toLoad.default(main);
-    } else if (toLoad.loadLazy) {
+    if (toLoad.loadLazy) {
       await toLoad.loadLazy(main);
     }
   }
@@ -278,6 +273,8 @@ async function loadEager(doc) {
 async function loadLazy(doc) {
   const main = doc.querySelector('main');
   await loadBlocks(main);
+  await loadLazyTemplate(universalTemplate, main);
+  await loadLazyTemplate(template, main);
 
   const { hash } = window.location;
   const element = hash ? doc.getElementById(hash.substring(1)) : false;
@@ -300,7 +297,12 @@ async function loadLazy(doc) {
  */
 function loadDelayed() {
   // eslint-disable-next-line import/no-cycle
-  window.setTimeout(() => import('./delayed.js'), 3000);
+  window.setTimeout(async () => {
+    const main = document.querySelector('main');
+    await loadDelayedTemplate(universalTemplate, main);
+    await loadDelayedTemplate(template, main);
+    import('./delayed.js');
+  }, 3000);
   // load anything that can be postponed to the latest here
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -31,33 +31,103 @@ async function loadFonts() {
 }
 
 /**
+ * @typedef Template
+ * @property {function} [default] Default export of the template, which will be called in the lazy
+ *  phase. Expects a single argument: the document's <main> HTMLElement.
+ * @property {function} [loadLazy] If provided, will be called in the lazy phase. If both a default
+ *  export and loadLazy function are provided, only the default export will be called. Expects a
+ *  single argument: the document's <main> HTMLElement.
+ * @property {function} [loadEager] If provided, will be called in the eager phase. Expects a single
+ *  argument: the document's <main> HTMLElement.
+ * @property {function} [loadDelayed] If provided, will be called in the delayed phase. Expects a
+ *  single argument: the document's <main> HTMLElement.
+ */
+
+/**
+ * @type {Template}
+ */
+let universalTemplate;
+/**
+ * @type {Template}
+ */
+let template;
+
+/**
+ * Invokes a template's eager method, if specified.
+ * @param {Template} [toLoad] Template whose eager method should be invoked.
+ * @param {HTMLElement} main The document's main element.
+ */
+async function loadEagerTemplate(toLoad, main) {
+  if (toLoad && toLoad.loadEager) {
+    await toLoad.loadEager(main);
+  }
+}
+
+/**
+ * Invokes a template's lazy method, if specified.
+ * @param {Template} [toLoad] Template whose lazy method should be invoked.
+ * @param {HTMLElement} main The document's main element.
+ */
+async function loadLazyTemplate(toLoad, main) {
+  if (toLoad) {
+    if (toLoad.default) {
+      await toLoad.default(main);
+    } else if (toLoad.loadLazy) {
+      await toLoad.loadLazy(main);
+    }
+  }
+}
+
+/**
+ * Invokes a template's delayed method, if specified.
+ * @param {Template} [toLoad] Template whose delayed method should be invoked.
+ * @param {HTMLElement} main The document's main element.
+ */
+async function loadDelayedTemplate(toLoad, main) {
+  if (toLoad && toLoad.loadDelayed) {
+    await toLoad.loadDelayed(main);
+  }
+}
+
+/**
+ * Loads a template by concurrently requesting its CSS and javascript files, and invoking its
+ * eager loading phase.
+ * @param {string} templateName The name of the template to load.
+ * @param {HTMLElement} main The document's main element.
+ * @returns {Promise<Template>} Resolves with the imported module after the template's files are
+ *  loaded and its eager phase is complete.
+ */
+async function loadTemplate(templateName, main) {
+  const cssLoaded = loadCSS(
+    `${window.hlx.codeBasePath}/templates/${templateName}/${templateName}.css`,
+  );
+  let module;
+  const decorateComplete = new Promise((resolve) => {
+    (async () => {
+      module = await import(
+        `../templates/${templateName}/${templateName}.js`
+      );
+      await loadEagerTemplate(module, main);
+      resolve();
+    })();
+  });
+  await Promise.all([cssLoaded, decorateComplete]);
+  return module;
+}
+
+/**
  * Run template specific decoration code.
  * @param {Element} main The container element
  */
 async function decorateTemplates(main) {
   try {
     // Load the universal template for every page
-    const universalTemplate = 'universal';
-    const universalMod = await import(
-      `../templates/${universalTemplate}/${universalTemplate}.js`
-    );
-    loadCSS(
-      `${window.hlx.codeBasePath}/templates/${universalTemplate}/${universalTemplate}.css`,
-    );
-    if (universalMod.default) {
-      await universalMod.default(main);
-    }
+    universalTemplate = await loadTemplate('universal', main);
 
-    const template = toClassName(getMetadata('template'));
+    const templateName = toClassName(getMetadata('template'));
     const templates = TEMPLATE_LIST;
-    if (templates.includes(template)) {
-      const mod = await import(`../templates/${template}/${template}.js`);
-      loadCSS(
-        `${window.hlx.codeBasePath}/templates/${template}/${template}.css`,
-      );
-      if (mod.default) {
-        await mod.default(main);
-      }
+    if (templates.includes(templateName)) {
+      template = await loadTemplate(templateName, main);
     }
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/templates/article/article.js
+++ b/templates/article/article.js
@@ -16,6 +16,7 @@ import {
  * for all articles.
  * @param {HTMLElement} main The page's main content.
  */
+// eslint-disable-next-line import/prefer-default-export
 export async function loadEager(main) {
   const path = window.location.pathname;
 

--- a/templates/article/article.js
+++ b/templates/article/article.js
@@ -16,7 +16,7 @@ import {
  * for all articles.
  * @param {HTMLElement} main The page's main content.
  */
-export default async function loadTemplate(main) {
+export async function loadEager(main) {
   const path = window.location.pathname;
 
   const article = await getRecordByPath(path);

--- a/templates/author/author.js
+++ b/templates/author/author.js
@@ -23,6 +23,7 @@ function addIcon(beforeElement, iconName) {
  * Manipulates the DOM as necessary to format the template.
  * @param {HTMLElement} main Main element of the page.
  */
+// eslint-disable-next-line import/prefer-default-export
 export async function loadEager(main) {
   const defaultContent = main.querySelector('.default-content-wrapper');
   if (!defaultContent) {

--- a/templates/author/author.js
+++ b/templates/author/author.js
@@ -23,7 +23,7 @@ function addIcon(beforeElement, iconName) {
  * Manipulates the DOM as necessary to format the template.
  * @param {HTMLElement} main Main element of the page.
  */
-export default async function decorate(main) {
+export async function loadEager(main) {
   const defaultContent = main.querySelector('.default-content-wrapper');
   if (!defaultContent) {
     return;

--- a/templates/category/category.js
+++ b/templates/category/category.js
@@ -23,7 +23,7 @@ function appendElementBeforeLast(target, last, toAppend) {
  * Modifies the DOM with additional elements required to display a category page.
  * @param {HTMLElement} main The page's main element.
  */
-export default async function decorate(main) {
+export async function loadEager(main) {
   const category = await getRecordByPath(window.location.pathname);
   if (!category) {
     return;

--- a/templates/category/category.js
+++ b/templates/category/category.js
@@ -23,6 +23,7 @@ function appendElementBeforeLast(target, last, toAppend) {
  * Modifies the DOM with additional elements required to display a category page.
  * @param {HTMLElement} main The page's main element.
  */
+// eslint-disable-next-line import/prefer-default-export
 export async function loadEager(main) {
   const category = await getRecordByPath(window.location.pathname);
   if (!category) {


### PR DESCRIPTION
This PR introduces the ability to load different parts of a template in the eager, lazy, or delayed phase. The motivation for this is to improve page load speeds.

For example, consider the category template. Part of that template's responsibility is to query for all articles that are in the current category. Depending on the size of the query-index, this might take a lot of time to execute. Rather than blocking the page from loading while the query runs, the template could do something like:

* Load skeleton article cards during the eager phase so the template gets its layout in place.
* During lazy, execute the query to retrieve the category's articles, then replace the skeleton cards with final content.
* For even heavier operations (that might be out of the viewport), templates could do that processing during the delayed phase.

The functionality works based on the names of the method(s) that the template exports:

* `loadEager()` will be called during the eager phase.
* `loadLazy()` will be called during lazy.
* `loadDelayed()` during delayed.

Test URLs:
Test URLs:
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/
- After: https://template-phases-final--channelco-crn-com--hlxsites.hlx.page/
- After: https://template-phases-final--channelco-crn-com--hlxsites.hlx.page/news/computing/
- After: https://template-phases-final--channelco-crn-com--hlxsites.hlx.page/authors/dylan-martin
- After: https://template-phases-final--channelco-crn-com--hlxsites.hlx.page/search?query=oracle
- After: https://template-phases-final--channelco-crn-com--hlxsites.hlx.page/news/managed-services/painful-decision-slalom-consulting-layoffs-hit-900-workers
