### PR TITLE
fix: preload universal template files since they're always used.

### DIFF
--- a/head.html
+++ b/head.html
@@ -2,3 +2,4 @@
 <script src="/scripts/lib-franklin.js" type="module"></script>
 <script src="/scripts/scripts.js" type="module"></script>
 <link rel="stylesheet" href="/styles/styles.css"/>
+<link rel="stylesheet" href="/templates/universal/universal.css"/>

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -48,7 +48,7 @@ async function loadFonts() {
 /**
  * @type {Template}
  */
-let universalTemplate = {
+const universalTemplate = {
   loadDelayed: universalLoadDelayed,
   loadEager: universalLoadEager,
   loadLazy: universalLoadLazy,

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -11,6 +11,11 @@ import {
 } from './lib-franklin.js';
 
 import { decorateMain } from './shared.js';
+import {
+  loadEager as universalLoadEager,
+  loadLazy as universalLoadLazy,
+  loadDelayed as universalLoadDelayed,
+} from '../templates/universal/universal.js';
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 
@@ -43,7 +48,11 @@ async function loadFonts() {
 /**
  * @type {Template}
  */
-let universalTemplate;
+let universalTemplate = {
+  loadDelayed: universalLoadDelayed,
+  loadEager: universalLoadEager,
+  loadLazy: universalLoadLazy,
+};
 /**
  * @type {Template}
  */
@@ -116,9 +125,6 @@ async function loadTemplate(templateName, main) {
  */
 async function decorateTemplates(main) {
   try {
-    // Load the universal template for every page
-    universalTemplate = await loadTemplate('universal', main);
-
     const templateName = toClassName(getMetadata('template'));
     const templates = TEMPLATE_LIST;
     if (templates.includes(templateName)) {

--- a/templates/universal/universal.js
+++ b/templates/universal/universal.js
@@ -111,3 +111,11 @@ export async function loadLazy(main) {
 
   document.body.appendChild(bottomAdSection);
 }
+
+export function loadEager() {
+  // no eager functionality
+}
+
+export function loadDelayed() {
+  // no delayed functionality
+}


### PR DESCRIPTION
I'm not sure if this would have much of an impact, but since we're _always_ using the universal template, this PR makes it so the template's css and javascript files aren't loaded dynamically. Do you think this would matter?

Test URLs:
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/
- After: https://optimize-loading--channelco-crn-com--hlxsites.hlx.page/
