### PR TITLE
fix: reduce CLS caused by universal template.

### DIFF
--- a/blocks/breadcrumb/breadcrumb.js
+++ b/blocks/breadcrumb/breadcrumb.js
@@ -9,6 +9,7 @@ function createBreadcrumbItem(href, label) {
 }
 
 export default function decorate(block) {
+  block.innerHTML = '';
   // If path ends with '/', pop the last item out. Then pop the current page
   const pathArr = window.location.pathname.split('/');
   if (pathArr[pathArr.length - 1] === '') pathArr.pop();

--- a/blocks/news-slider/news-slider.css
+++ b/blocks/news-slider/news-slider.css
@@ -175,10 +175,6 @@ main .section.news-slider-container {
   margin-top: 0;
 }
 
-#inthesubtaxonomies .dragdealer-background {
-  /* bottom: 2px; */
-}
-
 #inthetaxonomies-carousel .handle li.slide::before {
   margin-left: 8px;
   margin-right: 10px;
@@ -215,10 +211,6 @@ main .section.news-slider-container {
 }
 
 @media (min-width: 768px) {
-  .news-slider-wrapper {
-    padding: 0;
-  }
-
   .inthenews-header {
     width: 19%;
     padding-top: 19px;

--- a/blocks/news-slider/news-slider.js
+++ b/blocks/news-slider/news-slider.js
@@ -138,7 +138,7 @@ export default function decorate(block) {
     if (newsItems.length === 0) {
       h1 = block.querySelector('h1');
       h1.className = 'slider-title';
-      newsSlider.parentNode.insertBefore(h1, newsSlider);
+      block.replaceWith(h1);
       return;
     }
 

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -15,10 +15,10 @@ const DEFAULT_CATEGORY_NAME = 'News';
 const EMAIL_REGEX = /\S+[a-z0-9]@[a-z0-9.]+/img;
 
 /**
- * Builds breadcrumb menu and prepends to main in a new section
- * @param {Element} main The container element
+ * Builds breadcrumb menu and returns it.
+ * @returns {HTMLElement} Newly created bread crumb.
  */
-function buildBreadcrumb(main) {
+export function buildBreadcrumb() {
   const path = window.location.pathname;
   const title = document.querySelector('h1');
 
@@ -27,8 +27,10 @@ function buildBreadcrumb(main) {
   }
 
   const div = document.createElement('div');
-  div.append(buildBlock('breadcrumb', { elems: [] }));
-  main.prepend(div);
+  const breadcrumb = buildBlock('breadcrumb', { elems: [] });
+  div.append(breadcrumb);
+  decorateBlock(breadcrumb);
+  return div;
 }
 
 function buildList(name, elements) {
@@ -61,9 +63,13 @@ export function buildNewsSlider(main, title) {
   newsSliderBlock.classList.add('tabbed');
 
   div.append(newsSliderBlock);
-  main.prepend(div);
-
-  return newsSliderBlock;
+  const topSection = main.querySelector('.top-section');
+  if (!topSection) {
+    return;
+  }
+  topSection.append(div);
+  decorateBlock(newsSliderBlock);
+  return loadBlock(newsSliderBlock);
 }
 
 /**
@@ -116,7 +122,6 @@ function buildPageDivider(main) {
  */
 function buildAutoBlocks(main) {
   try {
-    buildBreadcrumb(main);
     buildEmbed(main);
     buildPageDivider(main);
   } catch (error) {

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -23,7 +23,7 @@ export function buildBreadcrumb() {
   const title = document.querySelector('h1');
 
   if (path === '/' || (title && title.innerText === '404')) {
-    return;
+    return undefined;
   }
 
   const div = document.createElement('div');
@@ -52,7 +52,7 @@ function buildList(name, elements) {
   return ul;
 }
 
-export function buildNewsSlider(main, title) {
+export async function buildNewsSlider(main, title) {
   const name = title;
   const elements = getMetadata('keywords');
 
@@ -69,7 +69,7 @@ export function buildNewsSlider(main, title) {
   }
   topSection.append(div);
   decorateBlock(newsSliderBlock);
-  return loadBlock(newsSliderBlock);
+  await loadBlock(newsSliderBlock);
 }
 
 /**

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -73,6 +73,10 @@
   }
 }
 
+html {
+  overflow-y: scroll;
+}
+
 body {
   font-size: var(--body-font-size-m);
   margin-left: auto;

--- a/templates/category/category.js
+++ b/templates/category/category.js
@@ -11,14 +11,6 @@ import {
   buildNewsSlider,
 } from '../../scripts/shared.js';
 
-function appendElementBeforeLast(target, last, toAppend) {
-  if (last) {
-    target.insertBefore(toAppend, last);
-  } else {
-    target.append(toAppend);
-  }
-}
-
 /**
  * Modifies the DOM with additional elements required to display a category page.
  * @param {HTMLElement} main The page's main element.
@@ -29,20 +21,34 @@ export async function loadEager(main) {
   if (!category) {
     return;
   }
-  let lastElement;
-  if (main.children.length > 0) {
-    lastElement = main.children.item(0);
-  }
+  buildNewsSlider(main, category.title);
+}
 
-  const newsSlider = buildNewsSlider(main, category.title);
-  decorateBlock(newsSlider);
+/**
+ * Modifies the DOM with additional elements required to display a category page.
+ * @param {HTMLElement} main The page's main element.
+ */
+// eslint-disable-next-line import/prefer-default-export
+export async function loadLazy(main) {
+  const category = await getRecordByPath(window.location.pathname);
+  if (!category) {
+    return;
+  }
+  let lastElement;
+  const contentSection = main.querySelector('.content-section');
+  if (!contentSection) {
+    return;
+  }
+  if (contentSection.children.length > 0) {
+    lastElement = contentSection.children.item(0);
+  }
 
   const articles = await getArticlesByCategory(category.title);
   articles.sort(comparePublishDate);
 
   buildArticleCardsBlock(articles.slice(0, 5), (leadCards) => {
     leadCards.classList.add('lead-article');
-    appendElementBeforeLast(main, lastElement, leadCards);
+    contentSection.insertBefore(leadCards, lastElement);
   });
 
   const newsLinkText = `${category.title} News`;
@@ -54,14 +60,14 @@ export async function loadEager(main) {
 
   const newsHeading = document.createElement('h2');
   newsHeading.append(newsLink);
-  appendElementBeforeLast(main, lastElement, newsHeading);
+  contentSection.insertBefore(newsHeading, lastElement);
 
   buildArticleCardsBlock(articles.slice(5, 13), (cards) => {
-    appendElementBeforeLast(main, lastElement, cards);
+    contentSection.insertBefore(cards, lastElement);
   });
 
   const categoryNavigation = buildBlock('category-navigation', { elems: [] });
-  main.append(categoryNavigation);
+  contentSection.append(categoryNavigation);
   decorateBlock(categoryNavigation);
   await loadBlock(categoryNavigation);
 }

--- a/templates/universal/universal.css
+++ b/templates/universal/universal.css
@@ -5,10 +5,6 @@ main {
   overflow: hidden;
 }
 
-main .main-content-container {
-  margin-top: 0;
-}
-
 .top-ad-section {
   padding-bottom: 20px;
   border-top: 2px solid #000000;
@@ -34,13 +30,10 @@ main .main-content-container {
   position: relative;
 }
 
-main .section.breadcrumb-container {
+main .breadcrumb-wrapper {
   margin: 0;
-  padding: 0;
-}
-
-main .section.breadcrumb-container .breadcrumb-wrapper {
-  max-width: unset;
+  padding: 0.25rem 0;
+  min-height: 35px;
 }
 
 .ad-title {
@@ -112,6 +105,10 @@ main .back-top-top-section-header {
   height: 626px;
 }
 
+main .content-section .section:first-child {
+  margin-top: 0;
+}
+
 @keyframes loading {
   0% {
     background-position: 200% 0;
@@ -141,42 +138,53 @@ main .back-top-top-section-header {
 }
 
 @media (min-width: 992px) {
-  main .content-and-ads-container {
+  /* avoids CLS before the right ad section moves into place */
+  main > .section {
+    margin-right: 330px;
+    padding-right: var(--padding-spacer-x);
+  }
+
+  /* avoids CLS before the right ad section moves into place */
+  main .right-ad-section {
+    display: none;
+  }
+
+  /* shows the right ad section once it moves into place */
+  main.grid-layout .right-ad-section {
+    display: block;
+  }
+
+  main.grid-layout .section {
+    margin: 0;
+    padding: 0;
+  }
+
+  main.grid-layout {
     display: grid;
     gap: var(--padding-spacer-x);
     grid-template-columns: auto 1fr 330px auto;
     grid-template-rows: auto auto;
     grid-template-areas:
-      '. news news .'
-      '. content ads .';
+      'top top top top'
+      '. content ads .'
+      'to-top to-top to-top to-top';
   }
 
-  main .content-and-ads-container .news-slider-wrapper {
-    grid-area: news;
-    grid-template: '. content ads .' / auto 1fr 330px auto;
+  main .top-section {
+    grid-area: top;
   }
 
-  main .content-and-ads-container .content-section {
+  main .content-section {
     grid-area: content;
-    margin: 0;
-    padding: 0;
   }
 
-  main .content-and-ads-container .content-section .section {
-    margin: 0;
-    padding: 0;
+  main .back-to-top {
+    grid-area: to-top;
   }
 
-  main .content-and-ads-container .right-ad-section {
+  main .right-ad-section {
     grid-area: ads;
     min-height: 700px;
-    margin: 0;
-    padding: 0;
-  }
-
-  main .content-and-ads-container .right-ad-section .section {
-    margin: 0;
-    padding: 0;
   }
 }
 

--- a/templates/universal/universal.js
+++ b/templates/universal/universal.js
@@ -1,3 +1,5 @@
+import { buildBreadcrumb } from '../../scripts/shared.js';
+
 function scrollToTop(event) {
   event.preventDefault();
   window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -39,18 +41,34 @@ function createToTopSection() {
  */
 // eslint-disable-next-line import/prefer-default-export
 export async function loadLazy(main) {
-  const mainContainer = document.createElement('div');
-  mainContainer.className = 'main-content-container';
-
+  // move all sections into a single container so that they can be
+  // placed in the correct location in the page's grid
   const contentSection = document.createElement('div');
   contentSection.className = 'content-section';
+
+  const rightAds = main.querySelector('.right-ad-section');
+  if (!rightAds) {
+    return;
+  }
+
+  [...main.querySelectorAll('main > .section')].forEach((section) => {
+    contentSection.appendChild(section);
+  });
+  main.insertBefore(contentSection, rightAds);
+  main.classList.add('grid-layout');
+}
+
+/**
+ * Loads the template's general layout onto the page.
+ * @param {HTMLElement} main The document's main element.
+ */
+export function loadEager(main) {
+  const topSection = document.createElement('div');
+  topSection.classList.add('top-section');
 
   const topAdSection = document.createElement('div');
   topAdSection.className = 'top-ad-section';
   topAdSection.id = 'top-ad-fragment-container';
-
-  const contentAndAdsContainer = document.createElement('div');
-  contentAndAdsContainer.className = 'content-and-ads-container';
 
   const rightAdSection = document.createElement('div');
   rightAdSection.className = 'right-ad-section';
@@ -75,39 +93,24 @@ export async function loadLazy(main) {
   });
 
   bottomAdSection.appendChild(closeIcon);
-  contentAndAdsContainer.appendChild(contentSection);
-  contentAndAdsContainer.appendChild(rightAdSection);
 
-  const breadcrumb = main.querySelector('.breadcrumb-container');
+  const breadcrumb = buildBreadcrumb();
   const newsWrapper = main.querySelector('.news-slider-wrapper');
 
+  topSection.appendChild(topAdSection);
   if (breadcrumb) {
-    main.insertBefore(topAdSection, breadcrumb);
-  } else {
-    main.prepend(topAdSection);
+    topSection.appendChild(breadcrumb);
   }
-
-  // Move remaining sections in main to contentSection
-  Array.from(main.children)
-    .filter((child) => child !== topAdSection && child !== breadcrumb)
-    .forEach((section) => {
-      contentSection.appendChild(section);
-    });
-
-  mainContainer.appendChild(contentAndAdsContainer);
-
   if (newsWrapper) {
-    contentAndAdsContainer.prepend(newsWrapper);
-    const newsContainer = main.querySelector('.news-slider-container');
-    if (newsContainer) {
-      newsContainer.classList.remove('news-slider-container');
-    }
+    newsWrapper.parentElement.classList.remove('news-slider-container');
+    topSection.appendChild(newsWrapper);
+    newsWrapper.parentElement.classList.add('news-slider-container');
   }
+  main.prepend(topSection);
+  main.append(rightAdSection);
 
   const toTopSection = createToTopSection();
-  mainContainer.appendChild(toTopSection);
-
-  main.appendChild(mainContainer);
+  main.appendChild(toTopSection);
 
   document.body.appendChild(bottomAdSection);
 }


### PR DESCRIPTION
This PR reduces most of the CLS caused by the universal template by moving everything it auto-blocks into the eager phase.

In the lazy phase it moves all the non-autoblocked content into a single container so that we can apply a grid layout to it. We don't do this in the eager phase because it breaks a lot of Franklin's OOTB section and block decorating.

There's still CLS to fix on several pages, but this at least takes care of the universal layout.

Test URLs:
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/
- After: https://universal-cls--channelco-crn-com--hlxsites.hlx.page/
- After: https://universal-cls--channelco-crn-com--hlxsites.hlx.page/news/computing/
- After: https://universal-cls--channelco-crn-com--hlxsites.hlx.page/authors/dylan-martin
- After: https://universal-cls--channelco-crn-com--hlxsites.hlx.page/search?query=oracle
- After: https://universal-cls--channelco-crn-com--hlxsites.hlx.page/news/managed-services/painful-decision-slalom-consulting-layoffs-hit-900-workers
