### PR TITLE
feat: move search-results block logic to new template.

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -14,7 +14,7 @@ import { decorateMain } from './shared.js';
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 
-const TEMPLATE_LIST = ['category', 'article', 'author'];
+const TEMPLATE_LIST = ['category', 'article', 'author', 'search-results'];
 
 /**
  * load fonts.css and set a session storage flag

--- a/templates/search-results/search-results.css
+++ b/templates/search-results/search-results.css
@@ -1,14 +1,11 @@
-.search-results {
-  border-top: 1px solid #8c8c8c;
-  padding-top: 2rem;
-}
-
 .search-results > h2 {
   border-bottom: 1px solid #8c8c8c;
   padding-bottom: 1rem;
 }
 
 .search-results form {
+  border-top: 1px solid #8c8c8c;
+  padding-top: 2rem;
   display: flex;
   gap: .5rem;
   align-items: center;

--- a/templates/search-results/search-results.js
+++ b/templates/search-results/search-results.js
@@ -28,31 +28,42 @@ function createSearchTermElement(term) {
 }
 
 /**
- * Modifies the DOM with additional elements required to display
- * search results.
- * @param {HTMLElement} block Default DOM structure for the block.
+ * Modifies the DOM as needed for search results, and queries
+ * for the results.
+ * @param {HTMLElement} main The page's main element.
+ * @returns {Promise} Resolves when the template has finished
+ *  loading.
  */
-export default async function decorate(block) {
+// eslint-disable-next-line import/prefer-default-export
+export async function loadLazy(main) {
   const params = new URLSearchParams(window.location.search);
   const searchTerm = String(params.get('query') || '').trim();
   let limit = parseInt(params.get('limit'), 10);
   if (!limit || limit > MAX_LIMIT) {
     limit = MAX_LIMIT;
   }
-  block.innerHTML = `
-    <form action="/search">
-      <input type="search" name="query" placeholder="Search" aria-label="Search" size="1" />
-      <button type="submit">Search</button>
-    </form>
+
+  const section = main.querySelector('.section');
+  if (!section) {
+    return;
+  }
+
+  const form = document.createElement('form');
+  form.setAttribute('action', '/search');
+  form.innerHTML = `
+    <input type="search" name="query" placeholder="Search" aria-label="Search" size="1" />
+    <button type="submit">Search</button>
   `;
+  section.append(form);
+
   const h1 = document.createElement('h1');
   h1.innerText = 'Showing results for ';
   h1.append(createSearchTermElement(searchTerm));
-  block.append(h1);
+  section.append(h1);
 
   const resultCountLabel = document.createElement('h2');
   resultCountLabel.innerText = 'Loading results...';
-  block.append(resultCountLabel);
+  section.append(resultCountLabel);
 
   let results = [];
   if (searchTerm) {
@@ -66,9 +77,9 @@ export default async function decorate(block) {
   termLabel.classList.add('quoted');
   resultCountLabel.append(termLabel);
 
-  await buildArticleCardsBlock(results.slice(0, limit), (cards) => block.append(cards));
+  await buildArticleCardsBlock(results.slice(0, limit), (cards) => section.append(cards));
   const nav = buildBlock('category-navigation', { elems: [] });
-  block.append(nav);
+  section.append(nav);
   decorateBlock(nav);
   await loadBlock(nav);
 }


### PR DESCRIPTION
The query performed by searching will potentially be heavy enough that page speed could benefit from the eager/lazy/delayed phase. The `search-results` block didn't provide the phases, so the block's logic was moved into a new template (which the `/search` doc uses) to provide more flexibility.

Test URLs:
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/search?query=oracle
- After: https://search-results-template--channelco-crn-com--hlxsites.hlx.page/search?query=oracle
