### PR TITLE
feat: load skeleton placeholders for cards

### DIFF
--- a/blocks/article-cards/article-cards.css
+++ b/blocks/article-cards/article-cards.css
@@ -42,6 +42,12 @@
   margin-top: 1rem;
 }
 
+.article-cards .article-card.skeleton > a {
+  display: inline-block;
+  width: 100%;
+  height: calc(100vw * .6);
+}
+
 /* lead article variant */
 .article-cards.lead-article,
 .article-cards.lead-article .sub-article .article-card:nth-child(odd) {
@@ -85,6 +91,11 @@
     aspect-ratio: 1 / 1;
   }
 
+  .article-cards .article-card.skeleton > a {
+    width: 100px;
+    height: 100px;
+  }
+
   /* lead article variant */
   .article-cards.lead-article .featured-article {
     display: block;
@@ -99,12 +110,22 @@
   .article-cards.lead-article .featured-article .article-card-description {
     margin-bottom: 2rem;
   }
+
+  .article-cards.lead-article .featured-article.skeleton > a {
+    width: 450px;
+    height: 280px;
+  }
 }
 
 @media (min-width: 1200px) {
   .article-cards .article-card picture img {
     max-height: 165px;
     max-width: 230px;
+  }
+
+  .article-cards .article-card.skeleton > a {
+    width: 165px;
+    height: 165px;
   }
 
   /* lead article variant */
@@ -144,5 +165,10 @@
 
   .article-cards.lead-article .sub-article .article-card:nth-child(n+3) {
     border-top: 2px dotted var(--color-mid-grey);
+  }
+
+  .article-cards.lead-article .article-card.skeleton > a {
+    height: 100px;
+    width: 170px;
   }
 }

--- a/blocks/article-cards/article-cards.js
+++ b/blocks/article-cards/article-cards.js
@@ -2,70 +2,209 @@ import {
   getCategoryName,
   getCategoryPath,
   createOptimizedPicture,
-  getRecordsFromBlock,
+  getPathsFromBlock,
   buildArticleAuthor,
 } from '../../scripts/shared.js';
 
 /**
+ * Builds the link to the article's category. The link will either be a placeholder
+ * or an actual link, depending on the provided parameters.
+ * @param {import('../../scripts/shared.js').QueryIndexRecord} [article] If provided, the
+ *  element will contain a link with the category name. Otherwise it will be a placeholder.
+ * @returns {HTMLElement} The card's category.
+ */
+function createCategoryName(article) {
+  const category = document.createElement('h3');
+  category.classList.add('article-card-category');
+  if (article) {
+    const categoryName = getCategoryName(article);
+    category.innerHTML = `
+      <a href="${getCategoryPath(article.path)}" class="link-arrow" aria-label="${categoryName}">${categoryName}</a>
+    `;
+  } else {
+    category.classList.add('placeholder');
+    category.innerText = 'Category';
+  }
+  return category;
+}
+
+/**
+ * Builds the article's title information. It will either be a placeholder skeleton
+ * or the actual title, depending on the provided parameters.
+ * @param {import('../../scripts/shared.js').QueryIndexRecord} [article] If provided, the
+ *  element will contain a link with the article title. Otherwise it will be a placeholder.
+ * @returns {HTMLElement} The card's title.
+ */
+function createTitle(article) {
+  const title = document.createElement('h5');
+  title.classList.add('article-card-title');
+  if (article) {
+    title.innerHTML = `
+      <a href="${article.path}" class="uncolored-link" aria-label="${article.title}">${article.title}</a>
+    `;
+  } else {
+    title.innerText = 'Article Title: Placeholder Text that will be Replaced with the Title';
+    title.classList.add('placeholder');
+  }
+  return title;
+}
+
+/**
+ * Builds the article's description information. It will either be a placeholder skeleton
+ * or the actual description, depending on the provided parameters.
+ * @param {import('../../scripts/shared.js').QueryIndexRecord} [article] If provided, the
+ *  element will contain the article's description. Otherwise it will be a placeholder.
+ * @returns {HTMLElement} The card's category.
+ */
+function createDescription(article) {
+  const description = document.createElement('p');
+  description.classList.add('article-card-description');
+  if (article) {
+    description.innerText = article.description;
+  } else {
+    description.classList.add('placeholder');
+    description.innerText = 'A summary description of the article that will be displayed in the card. This is placeholder text that will be replaced with information about the article.';
+  }
+  return description;
+}
+
+/**
+ * Builds the article's picture element. It will either be a placeholder skeleton
+ * or the actual picture, depending on the provided parameters.
+ * @param {boolean} isFeatured Should be true if the card is the featured card.
+ * @param {import('../../scripts/shared.js').QueryIndexRecord} [article] If provided, the
+ *  element will contain the article's picture. Otherwise it will be a placeholder.
+ * @returns {HTMLElement} The card's picture.
+ */
+function createPicture(article, isFeatured) {
+  const articlePictureLink = document.createElement('a');
+  if (article) {
+    articlePictureLink.href = article.path;
+    articlePictureLink.setAttribute('aria-label', article.title);
+    const articlePicture = createOptimizedPicture(article.image, article.title, isFeatured);
+    articlePictureLink.append(articlePicture);
+    const articleImage = articlePicture.querySelector('img');
+    articleImage.title = article.title;
+  } else {
+    articlePictureLink.classList.add('placeholder');
+  }
+  return articlePictureLink;
+}
+
+/**
+ * Creates an element containing all the information for an article. The card will either
+ * be a placeholder, or display an article's actual information, depending on the provided
+ * parameters.
+ * @param {string} [path] Full path to the article represented by the card. If provided,
+ *  will be set as the card's data-path.
+ * @param {boolean} [isFeatured] Should be true to create a card for the featured article.
+ * @param {import('../../scripts/shared.js').QueryIndexRecord} [article] If provided, the
+ *  card will contain the information from the given article. Otherwise the card will be
+ *  a placeholder.
+ * @returns {HTMLElement} Card information for an article.
+ */
+function createCard(path, isFeatured = false, article = false) {
+  const cardDiv = document.createElement('div');
+  cardDiv.classList.add('article-card');
+
+  if (!article) {
+    cardDiv.classList.add('skeleton');
+  }
+
+  if (isFeatured) {
+    cardDiv.classList.add('featured-article');
+  }
+
+  if (path) {
+    cardDiv.dataset.path = path;
+  }
+
+  const category = createCategoryName(article);
+  const title = createTitle(article);
+  const author = buildArticleAuthor(article);
+  const description = createDescription(article);
+
+  const infoDiv = document.createElement('div');
+  infoDiv.append(category);
+  infoDiv.append(title);
+  infoDiv.append(author);
+  infoDiv.append(description);
+
+  const articlePicture = createPicture(article, isFeatured);
+  cardDiv.append(articlePicture);
+  cardDiv.append(infoDiv);
+
+  return cardDiv;
+}
+
+function getPath(paths, index) {
+  if (paths.length > index) {
+    return paths[index];
+  }
+  return false;
+}
+
+/**
  * Converts the cards block from its authored format into HTML.
+ *
+ * Loading the cards fully requires action by something external to the block. During
+ * the eager phase, the block will load placeholders based on the number of list items
+ * (which must be links whose href and text are the same) contained in the block's
+ * content. Each placeholder card will have a data-path attribute containing the path to
+ * the article represented by the card.
+ *
+ * As an alternative to list items with article URLs, setting data-card-count on the
+ * block will instruct the block to create the specified number of card placeholders.
+ *
+ * The cards rely on something setting each card's data-json attribute to the stringified
+ * JSON of the article content that should be loaded into the card. Once this attribute is
+ * set, the block will replace the placeholder card with an actual card based on the JSON.
+ *
+ * As an example, during the lazy phase the universal template will find all placeholder
+ * cards on the page, query the index for articles base on each placeholder's data-path,
+ * then set the data-json on each card with record data from the index.
  * @param {HTMLElement} block The block's element on the page.
  */
-export default async function decorate(block) {
-  // retrieve article information for all specified article urls
-  const articles = await getRecordsFromBlock(block);
-
+export default function decorate(block) {
   const blockTarget = block.children.item(0).children.item(0);
   if (!blockTarget) {
     return;
   }
 
+  let cardCount = block.dataset.cardCount || 0;
+  // retrieve article information for all specified article urls
+  const articlePaths = getPathsFromBlock(block);
+
+  if (articlePaths.length) {
+    cardCount = articlePaths.length;
+  }
+
+  if (!cardCount) {
+    return;
+  }
+
   const addlArticleContainer = document.createElement('div');
   addlArticleContainer.classList.add('sub-article');
+
+  const featured = createCard(getPath(articlePaths, 0), true);
+  blockTarget.append(featured);
   // add article cards for each article
-  articles.forEach((article, index) => {
-    const cardDiv = document.createElement('div');
-    cardDiv.classList.add('article-card');
-
-    const category = document.createElement('h3');
-    category.classList.add('article-card-category');
-    const categoryName = getCategoryName(article);
-    category.innerHTML = `
-      <a href="${getCategoryPath(article.path)}" class="link-arrow" aria-label="${categoryName}">${categoryName}</a>
-    `;
-
-    const title = document.createElement('h5');
-    title.classList.add('article-card-title');
-    title.innerHTML = `
-      <a href="${article.path}" class="uncolored-link" aria-label="${article.title}">${article.title}</a>
-    `;
-
-    const author = buildArticleAuthor(article);
-    const description = document.createElement('p');
-    description.classList.add('article-card-description');
-    description.innerText = article.description;
-
-    const infoDiv = document.createElement('div');
-    infoDiv.append(category);
-    infoDiv.append(title);
-    infoDiv.append(author);
-    infoDiv.append(description);
-
-    const articlePictureLink = document.createElement('a');
-    articlePictureLink.href = article.path;
-    articlePictureLink.setAttribute('aria-label', article.title);
-    const articlePicture = createOptimizedPicture(article.image, article.title, index === 0);
-    articlePictureLink.append(articlePicture);
-    const articleImage = articlePicture.querySelector('img');
-    articleImage.title = article.title;
-    cardDiv.append(articlePictureLink);
-    cardDiv.append(infoDiv);
-
-    if (index > 0) {
-      addlArticleContainer.append(cardDiv);
-    } else {
-      cardDiv.classList.add('featured-article');
-      blockTarget.append(cardDiv);
-    }
-  });
+  for (let i = 1; i < cardCount; i += 1) {
+    const cardDiv = createCard(getPath(articlePaths, i));
+    addlArticleContainer.append(cardDiv);
+  }
   blockTarget.append(addlArticleContainer);
+
+  // listens for attribute modifications on child elements, and will replace a placeholder card
+  // with an actual card when a skeleton's data-json attribute is set
+  const observer = new MutationObserver((entries) => {
+    entries.forEach((entry) => {
+      if (entry.type === 'attributes' && entry.target.classList.contains('skeleton') && entry.target.dataset.json) {
+        const article = JSON.parse(entry.target.dataset.json);
+        const finalCard = createCard(article.path, entry.target.classList.contains('featured-article'), article);
+        entry.target.parentNode.replaceChild(finalCard, entry.target);
+      }
+    });
+  });
+  observer.observe(blockTarget, { attributes: true, subtree: true });
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -307,6 +307,18 @@ main .back-top-top-section-header::before {
   content: '▲';
 }
 
+main .placeholder {
+  position: relative;
+}
+
+main .placeholder::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  background-color: var(--overlay-background-color);
+}
+
 @media (min-width: 576px) {
   main .section > div {
     max-width: 540px;

--- a/templates/author/author.js
+++ b/templates/author/author.js
@@ -85,10 +85,6 @@ export async function loadEager(main) {
   const ad = buildBlock('ad', [[{ elems: [adIdLabel, adId] }, { elems: [adTypeLabel, adType] }]]);
   defaultContent.append(ad);
   decorateBlock(ad);
-
-  const navigation = buildBlock('category-navigation', { elems: [] });
-  defaultContent.append(navigation);
-  decorateBlock(navigation);
 }
 
 /**
@@ -96,9 +92,18 @@ export async function loadEager(main) {
  * @param {HTMLElement} main Main element of the page.
  */
 export async function loadLazy(main) {
+  const defaultContent = main.querySelector('.default-content-wrapper');
+  if (!defaultContent) {
+    return;
+  }
   const authorName = getMetadata('author');
   const articles = await getArticlesByAuthor(authorName);
   articles.sort(comparePublishDate);
 
   loadTemplateArticleCards(main, 'author', articles);
+
+  const navigation = buildBlock('category-navigation', { elems: [] });
+  defaultContent.append(navigation);
+  decorateBlock(navigation);
+  await loadBlock(navigation);
 }

--- a/templates/author/author.js
+++ b/templates/author/author.js
@@ -10,6 +10,7 @@ import {
   getArticlesByAuthor,
   comparePublishDate,
   buildArticleCardsBlock,
+  loadTemplateArticleCards,
 } from '../../scripts/shared.js';
 
 function addIcon(beforeElement, iconName) {
@@ -55,7 +56,6 @@ export async function loadEager(main) {
   block.classList.add('author');
   defaultContent.append(block);
   decorateBlock(block);
-  await loadBlock(block);
   decorateIcons(block);
 
   const authorName = getMetadata('author');
@@ -68,11 +68,9 @@ export async function loadEager(main) {
   `;
   defaultContent.append(newsLink);
 
-  const articles = await getArticlesByAuthor(authorName);
-  articles.sort(comparePublishDate);
-
-  await buildArticleCardsBlock(
-    articles.slice(0, 15),
+  buildArticleCardsBlock(
+    15,
+    'author',
     (articleCards) => defaultContent.append(articleCards),
   );
 
@@ -87,10 +85,20 @@ export async function loadEager(main) {
   const ad = buildBlock('ad', [[{ elems: [adIdLabel, adId] }, { elems: [adTypeLabel, adType] }]]);
   defaultContent.append(ad);
   decorateBlock(ad);
-  await loadBlock(ad);
 
   const navigation = buildBlock('category-navigation', { elems: [] });
   defaultContent.append(navigation);
   decorateBlock(navigation);
-  await loadBlock(navigation);
+}
+
+/**
+ * Manipulates the DOM as necessary to format the template.
+ * @param {HTMLElement} main Main element of the page.
+ */
+export async function loadLazy(main) {
+  const authorName = getMetadata('author');
+  const articles = await getArticlesByAuthor(authorName);
+  articles.sort(comparePublishDate);
+
+  loadTemplateArticleCards(main, 'author', articles);
 }

--- a/templates/category/category.js
+++ b/templates/category/category.js
@@ -9,6 +9,7 @@ import {
   comparePublishDate,
   buildArticleCardsBlock,
   buildNewsSlider,
+  loadTemplateArticleCards,
 } from '../../scripts/shared.js';
 
 /**
@@ -22,6 +23,35 @@ export async function loadEager(main) {
     return;
   }
   buildNewsSlider(main, category.title);
+
+  let lastElement;
+  const firstSection = main.querySelector('.section');
+  if (!firstSection) {
+    return;
+  }
+  if (firstSection.children.length > 0) {
+    lastElement = firstSection.children.item(0);
+  }
+
+  buildArticleCardsBlock(5, 'category', (leadCards) => {
+    leadCards.classList.add('lead-article');
+    firstSection.insertBefore(leadCards, lastElement);
+  });
+
+  const newsLinkText = `${category.title} News`;
+  const newsLink = document.createElement('a');
+  newsLink.title = newsLinkText;
+  newsLink.ariaLabel = newsLinkText;
+  newsLink.classList.add('link-arrow');
+  newsLink.innerText = newsLinkText;
+
+  const newsHeading = document.createElement('h2');
+  newsHeading.append(newsLink);
+  firstSection.insertBefore(newsHeading, lastElement);
+
+  buildArticleCardsBlock(8, 'category', (cards) => {
+    firstSection.insertBefore(cards, lastElement);
+  });
 }
 
 /**
@@ -34,37 +64,15 @@ export async function loadLazy(main) {
   if (!category) {
     return;
   }
-  let lastElement;
   const contentSection = main.querySelector('.content-section');
   if (!contentSection) {
     return;
-  }
-  if (contentSection.children.length > 0) {
-    lastElement = contentSection.children.item(0);
   }
 
   const articles = await getArticlesByCategory(category.title);
   articles.sort(comparePublishDate);
 
-  buildArticleCardsBlock(articles.slice(0, 5), (leadCards) => {
-    leadCards.classList.add('lead-article');
-    contentSection.insertBefore(leadCards, lastElement);
-  });
-
-  const newsLinkText = `${category.title} News`;
-  const newsLink = document.createElement('a');
-  newsLink.title = newsLinkText;
-  newsLink.ariaLabel = newsLinkText;
-  newsLink.classList.add('link-arrow');
-  newsLink.innerText = newsLinkText;
-
-  const newsHeading = document.createElement('h2');
-  newsHeading.append(newsLink);
-  contentSection.insertBefore(newsHeading, lastElement);
-
-  buildArticleCardsBlock(articles.slice(5, 13), (cards) => {
-    contentSection.insertBefore(cards, lastElement);
-  });
+  loadTemplateArticleCards(main, 'category', articles);
 
   const categoryNavigation = buildBlock('category-navigation', { elems: [] });
   contentSection.append(categoryNavigation);


### PR DESCRIPTION
This PR optimizes any page that uses article cards. The cards now work as follows:

* Card "skeletons" are loaded during the eager phase. The skeletons are just the basic structure of a card, with greyed-out backgrounds to indicate where content will eventually go.
* During the lazy phase, a template will query for card data and set a `data-json` on each article card skeleton. The article-cards block listens for this attribute modification, then replaces the skeleton with actual content based on the json.

Test URLs:
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/
- After: https://article-cards-skeleton--channelco-crn-com--hlxsites.hlx.page/
- After: https://article-cards-skeleton--channelco-crn-com--hlxsites.hlx.page/authors/dylan-martin
- After: https://article-cards-skeleton--channelco-crn-com--hlxsites.hlx.page/news/computing/
- After: https://article-cards-skeleton--channelco-crn-com--hlxsites.hlx.page/search?query=oracle