### PR TITLE
fix: optimize article template

### DIFF
--- a/templates/article/article.css
+++ b/templates/article/article.css
@@ -71,3 +71,11 @@
 .article main .related-content {
   margin-top: 1rem;
 }
+
+.article main .article-author.placeholder {
+  width: 150px;
+}
+
+.article main .article-date.placeholder {
+  width: 200px;
+}

--- a/templates/article/article.js
+++ b/templates/article/article.js
@@ -17,16 +17,8 @@ import {
  * @param {HTMLElement} main The page's main content.
  */
 // eslint-disable-next-line import/prefer-default-export
-export async function loadEager(main) {
+export function loadEager(main) {
   const path = window.location.pathname;
-
-  const article = await getRecordByPath(path);
-  if (!article) {
-    return;
-  }
-  const categoryPath = getCategoryPath(path);
-  const categoryName = getCategoryName(article);
-  const author = await getAuthorByName(article.author);
 
   const heading = main.querySelector('h1');
   if (!heading) {
@@ -40,20 +32,56 @@ export async function loadEager(main) {
   buildSocialShare(picture);
 
   const categoryLink = document.createElement('a');
-  categoryLink.classList.add('link-arrow', 'article-category-link');
-  categoryLink.innerText = categoryName;
-  categoryLink.href = categoryPath;
-  categoryLink.title = categoryName;
-  categoryLink['aria-label'] = categoryName;
+  categoryLink.classList.add('link-arrow', 'article-category-link', 'placeholder');
+  categoryLink.innerText = 'Category';
   heading.parentElement.insertBefore(categoryLink, heading);
 
-  const authorContainer = buildArticleAuthor(article);
+  const authorContainer = buildArticleAuthor();
   heading.parentElement.insertBefore(authorContainer, heading.nextSibling);
+}
 
-  await buildLearnMore(heading.parentElement, article.keywords);
+/**
+ * Processes the DOM as necessary in order to auto block items required
+ * for all articles.
+ * @param {HTMLElement} main The page's main content.
+ */
+// eslint-disable-next-line import/prefer-default-export
+export async function loadLazy(main) {
+  const path = window.location.pathname;
+  const article = await getRecordByPath(path);
+  if (!article) {
+    return;
+  }
+
+  const categoryPath = getCategoryPath(path);
+  const categoryName = getCategoryName(article);
+
+  const categoryPlaceholder = main.querySelector('.article .article-category-link');
+  if (categoryPlaceholder) {
+    const categoryLink = document.createElement('a');
+    categoryLink.classList.add('link-arrow', 'article-category-link');
+    categoryLink.innerText = categoryName;
+    categoryLink.href = categoryPath;
+    categoryLink.title = categoryName;
+    categoryLink.ariaLabel = categoryName;
+    categoryPlaceholder.replaceWith(categoryLink);
+  }
+
+  const authorPlaceholder = main.querySelector('.article .article-author-container');
+  if (authorPlaceholder) {
+    authorPlaceholder.replaceWith(buildArticleAuthor(article));
+  }
+
+  const contentSection = main.querySelector('.content-section');
+  if (!contentSection) {
+    return;
+  }
+
+  const author = await getAuthorByName(article.author);
+  await buildLearnMore(contentSection, article.keywords);
   if (author) {
-    await buildAuthorBlades(heading.parentElement, [author]);
-    const authorLink = heading.parentElement.querySelector(
+    await buildAuthorBlades(contentSection, [author]);
+    const authorLink = contentSection.querySelector(
       '.blade.author .blade-text a',
     );
     if (authorLink) {
@@ -62,5 +90,5 @@ export async function loadEager(main) {
   }
 
   const related = await getRelatedArticles(article);
-  await buildRelatedContent(heading.parentElement, related);
+  await buildRelatedContent(contentSection, related);
 }

--- a/templates/article/article.js
+++ b/templates/article/article.js
@@ -18,8 +18,6 @@ import {
  */
 // eslint-disable-next-line import/prefer-default-export
 export function loadEager(main) {
-  const path = window.location.pathname;
-
   const heading = main.querySelector('h1');
   if (!heading) {
     return;

--- a/templates/author/author.js
+++ b/templates/author/author.js
@@ -25,7 +25,7 @@ function addIcon(beforeElement, iconName) {
  * @param {HTMLElement} main Main element of the page.
  */
 // eslint-disable-next-line import/prefer-default-export
-export async function loadEager(main) {
+export function loadEager(main) {
   const defaultContent = main.querySelector('.default-content-wrapper');
   if (!defaultContent) {
     return;


### PR DESCRIPTION
Optimizes the article template by loading anything dependent on querying the index in the lazy phase. The eager phase will add placeholders for these elements (such as the category name and author). The net result is that the initial load of the page isn't dependent on querying the index, so visitors will see the article content faster.

Test URLs:
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/news/managed-services/painful-decision-slalom-consulting-layoffs-hit-900-workers
- After: https://article-template-opt--channelco-crn-com--hlxsites.hlx.page/news/managed-services/painful-decision-slalom-consulting-layoffs-hit-900-workers
