### PR TITLE
feat: add tag template

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -14,7 +14,7 @@ import { decorateMain } from './shared.js';
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 
-const TEMPLATE_LIST = ['category', 'article', 'author', 'search-results'];
+const TEMPLATE_LIST = ['category', 'article', 'author', 'search-results', 'tag'];
 
 /**
  * load fonts.css and set a session storage flag

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -928,3 +928,21 @@ export function loadTemplateArticleCards(main, templateName, articles) {
     }
   });
 }
+
+/**
+ * Determines whether a given value is in a list of comma-separated values.
+ * @param {string} list Comma-separated list to check.
+ * @param {string} value Value to look for.
+ * @returns {boolean} True if the given value is in the comma-separated
+ *  list, false otherwise.
+ */
+export function commaSeparatedListContains(list, value) {
+  if (!list || !value) {
+    return false;
+  }
+  const listStr = String(list);
+
+  return listStr.split(',')
+    .map((item) => item.trim())
+    .includes(value);
+}

--- a/templates/tag/tag.css
+++ b/templates/tag/tag.css
@@ -1,0 +1,13 @@
+.tag main h1 {
+  color: var(--link-color);
+  margin-top: 0;
+  padding-top: 0;
+}
+
+.tag main .article-card-title a {
+  color: var(--text-color);
+}
+
+.tag main .article-cards .article-card {
+  border-bottom: 2px dotted var(--color-mid-grey);
+}

--- a/templates/tag/tag.js
+++ b/templates/tag/tag.js
@@ -1,0 +1,67 @@
+import {
+  buildBlock,
+  decorateBlock,
+  loadBlock,
+} from '../../scripts/lib-franklin.js';
+import {
+  getRecordByPath,
+  buildArticleCardsBlock,
+  commaSeparatedListContains,
+  queryIndex,
+  isArticle,
+  comparePublishDate,
+  loadTemplateArticleCards,
+} from '../../scripts/shared.js';
+
+/**
+ * Modifies the DOM as needed for the template.
+ * @param {HTMLElement} main The page's main element.
+ */
+export function loadEager(main) {
+  const firstSection = main.querySelector('.section');
+  if (!firstSection) {
+    return;
+  }
+
+  buildArticleCardsBlock(10, 'tag', (cards) => { firstSection.prepend(cards); });
+
+  const title = document.createElement('h1');
+  title.innerText = 'Keyword';
+  title.classList.add('tag-title', 'placeholder');
+  firstSection.prepend(title);
+}
+
+/**
+ * Modifies the DOM as needed for the template.
+ * @param {HTMLElement} main The page's main element.
+ */
+export async function loadLazy(main) {
+  const tag = await getRecordByPath(window.location.pathname);
+  if (!tag) {
+    return;
+  }
+
+  const tagName = tag.keywords;
+  const heading = main.querySelector('.tag-title');
+  if (heading) {
+    const tagHeading = document.createElement('h1');
+    tagHeading.innerText = tagName;
+    heading.replaceWith(tagHeading);
+  }
+
+  const records = await queryIndex((record) => isArticle(record)
+    && commaSeparatedListContains(record.keywords, tagName));
+  records.sort(comparePublishDate);
+
+  loadTemplateArticleCards(main, 'tag', records);
+
+  const contentSection = main.querySelector('.content-section');
+  if (!contentSection) {
+    return;
+  }
+
+  const nav = buildBlock('category-navigation', { elems: [] });
+  contentSection.append(nav);
+  decorateBlock(nav);
+  await loadBlock(nav);
+}


### PR DESCRIPTION
Adds a template for displaying articles related to a tag (keyword).

Fix #69 

Test URLs:
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/tag/Notebooks/
- After: https://issue-69--channelco-crn-com--hlxsites.hlx.page/tag/Notebooks/
