### PR TITLE
feat: add company template

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -14,7 +14,7 @@ import { decorateMain } from './shared.js';
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 
-const TEMPLATE_LIST = ['category', 'article', 'author', 'search-results', 'tag'];
+const TEMPLATE_LIST = ['category', 'article', 'author', 'search-results', 'tag', 'company'];
 
 /**
  * load fonts.css and set a session storage flag

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -164,7 +164,7 @@ a:hover {
   text-decoration: none;
 }
 
-a.link-arrow::after {
+.link-arrow::after {
   content: '▶';
   display: inline-block;
   margin-left: .5rem;

--- a/templates/company/company.css
+++ b/templates/company/company.css
@@ -1,0 +1,21 @@
+.company main h1 {
+  color: var(--link-color);
+  margin-top: 0;
+  padding-top: 0;
+  padding-bottom: 2rem;
+  border-bottom: 2px solid #c5c5c5;
+}
+
+.company main .content-section .section > h2,
+.company main .content-section .section > a > h2 {
+  color: var(--link-color);
+  text-transform: uppercase;
+}
+
+.company main .content-section .section > a > h2 {
+  display: inline-block;
+}
+
+.company main .article-card-title a {
+  color: var(--text-color);
+}

--- a/templates/company/company.js
+++ b/templates/company/company.js
@@ -1,0 +1,61 @@
+import {
+  getRecordByPath,
+  comparePublishDate,
+  queryIndex,
+  isArticle,
+  commaSeparatedListContains,
+  buildArticleCardsBlock,
+  loadTemplateArticleCards,
+} from '../../scripts/shared.js';
+
+/**
+ * Modifies the DOM as needed for the template.
+ * @param {HTMLElement} main The page's main element.
+ */
+export function loadEager(main) {
+  const firstSection = main.querySelector('.section');
+  if (!firstSection) {
+    return;
+  }
+
+  buildArticleCardsBlock(8, 'company', (cards) => { firstSection.prepend(cards); });
+
+  const h2 = document.createElement('h2');
+  h2.classList.add('link-arrow');
+  h2.innerText = 'More News';
+  firstSection.prepend(h2);
+
+  buildArticleCardsBlock(5, 'company', (cards) => {
+    cards.classList.add('lead-article');
+    firstSection.prepend(cards);
+  });
+
+  const h1 = document.createElement('h1');
+  h1.innerText = 'Company';
+  h1.classList.add('company-heading', 'placeholder');
+  firstSection.prepend(h1);
+}
+
+/**
+ * Modifies the DOM as needed for the template.
+ * @param {HTMLElement} main The page's main element.
+ */
+export async function loadLazy(main) {
+  const company = await getRecordByPath(window.location.pathname);
+  if (!company) {
+    return;
+  }
+
+  const companyName = company.companynames;
+  const heading = main.querySelector('.company-heading');
+  if (heading) {
+    const newHeading = document.createElement('h1');
+    newHeading.innerText = companyName;
+    heading.replaceWith(newHeading);
+  }
+  const articles = await queryIndex((record) => isArticle(record)
+    && commaSeparatedListContains(record.companynames, companyName));
+  articles.sort(comparePublishDate);
+
+  loadTemplateArticleCards(main, 'company', articles);
+}


### PR DESCRIPTION
Adds a new template for company pages, which loads article cards for a company.

Fix #86 

Test URLs:
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/news/oracle-dwp
- After: https://issue-86-2--channelco-crn-com--hlxsites.hlx.page/news/oracle-dwp
