### PR TITLE
feat: place ads in article cards

### DIFF
--- a/blocks/ad/ad.js
+++ b/blocks/ad/ad.js
@@ -27,5 +27,8 @@ export default function decorate(block) {
   const divContainers = block.querySelectorAll('div > div');
   divContainers.forEach((div) => div.remove());
 
-  block.append(buildAdBlock(unitId, type));
+  const adBlock = buildAdBlock(unitId, type);
+  if (adBlock) {
+    block.append(adBlock);
+  }
 }

--- a/blocks/ad/ad.js
+++ b/blocks/ad/ad.js
@@ -1,3 +1,5 @@
+import { buildAdBlock } from '../../scripts/shared.js';
+
 export default function decorate(block) {
   // Extract the unit-id from the block
   const unitIdElement = block.querySelector(
@@ -21,40 +23,9 @@ export default function decorate(block) {
   }
   const type = typeElement.textContent;
 
-  // Determine the text and class based on the type
-  let adText;
-  let adClass;
-  let height;
-  if (type === 'Advertisement') {
-    adText = 'Advertisement';
-    adClass = 'right-ad';
-    height = 'fixed-height';
-  } else if (type === 'Sponsored post') {
-    adText = 'Sponsored post';
-    adClass = 'right-sponsored';
-  } else {
-    // eslint-disable-next-line no-console
-    console.error('Unknown type in the block');
-    return;
-  }
-
   // Remove the divs containing the 'id', 'unit-id', 'type', and the type value
   const divContainers = block.querySelectorAll('div > div');
   divContainers.forEach((div) => div.remove());
 
-  // Build the ad using the extracted unit-id and determined text and class
-  const rightAdHTML = `
-    <!-- AD IMU  STARTS  -->
-
-    <div class="${adClass} ${height}">
-      <span class="ad-title">${adText}</span> <br />
-      <div id="${unitId}" class="tmsads"></div>
-    </div>
-
-    <br clear="all">
-  `;
-
-  const range = document.createRange();
-  const rightAdEl = range.createContextualFragment(rightAdHTML);
-  block.append(rightAdEl);
+  block.append(buildAdBlock(unitId, type));
 }

--- a/blocks/article-cards/article-cards.css
+++ b/blocks/article-cards/article-cards.css
@@ -48,6 +48,18 @@
   height: calc(100vw * .6);
 }
 
+.article-cards .article-cards-ad {
+  background-color: #e6e6e6;
+  text-align: center;
+  padding: 0 1rem;
+  margin-top: 1rem;
+}
+
+.article-cards .sub-article .article-cards-ad {
+  width: 100%;
+  margin-bottom: auto;
+}
+
 /* lead article variant */
 .article-cards.lead-article,
 .article-cards.lead-article .sub-article .article-card:nth-child(odd) {
@@ -77,6 +89,8 @@
 
 .article-cards.lead-article .featured-article .article-card-description {
   display: block;
+  border-bottom: 2px dotted #a7a7a7;
+  padding-bottom: 2rem;
 }
 
 @media (min-width: 576px) {

--- a/blocks/article-cards/article-cards.css
+++ b/blocks/article-cards/article-cards.css
@@ -144,17 +144,30 @@
 
   /* lead article variant */
   .article-cards.lead-article > div > div {
-    flex-direction: row;
+    display: grid;
+    gap: 1rem;
+    grid-template:
+      "featured sub-articles" auto
+      "featured sub-articles-ad" auto
+      "featured ." 1fr / 1fr 1fr;
   }
 
-  .article-cards.lead-article .featured-article,
-  .article-cards.lead-article .sub-article {
-    flex: 1;
+  .article-cards.lead-article .featured-article {
+    grid-area: featured;
+  }
+
+  .article-cards.lead-article .article-cards-ad {
+    min-height: 325px;
   }
 
   .article-cards.lead-article .sub-article {
     display: flex;
     flex-wrap: wrap;
+    grid-area: sub-articles;
+  }
+
+  .article-cards.lead-article > div > div > .article-cards-ad {
+    grid-area: sub-articles-ad;
   }
 
   .article-cards.lead-article .sub-article .article-card {

--- a/blocks/article-cards/article-cards.js
+++ b/blocks/article-cards/article-cards.js
@@ -1,7 +1,4 @@
 import {
-  decorateBlock,
-} from '../../scripts/lib-franklin.js';
-import {
   getCategoryName,
   getCategoryPath,
   createOptimizedPicture,
@@ -156,7 +153,10 @@ function getPath(paths, index) {
 function buildAd(id, type) {
   const ad = document.createElement('div');
   ad.classList.add('article-cards-ad');
-  ad.append(buildAdBlock(id, type));
+  const adBlock = buildAdBlock(id, type);
+  if (adBlock) {
+    ad.append(adBlock);
+  }
   return ad;
 }
 
@@ -214,7 +214,7 @@ export default function decorate(block) {
   blockTarget.append(addlArticleContainer);
 
   if (includeAds && cardCount < 6) {
-    addlArticleContainer.append(buildAd('unit-1661973671931', 'Sponsored post'));
+    blockTarget.append(buildAd('unit-1661973671931', 'Sponsored post'));
   }
 
   // listens for attribute modifications on child elements, and will replace a placeholder card

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -933,31 +933,36 @@ export function loadTemplateArticleCards(main, templateName, articles) {
  * Builds an ad block with the given ID and type.
  * @param {string} unitId ID of the ad to include in the block.
  * @param {string} type The type of ad to create.
- * @returns {HTMLElement} Newly built ad block.
+ * @param {boolean} [fixedHeight] If true, the ad will have a fixed height
+ *  associated with it.
+ * @returns {HTMLElement} Newly built ad block. Will be falsy if the ad type
+ *  is unknown.
  */
-export function buildAdBlock(unitId, type) {
+export function buildAdBlock(unitId, type, fixedHeight = false) {
   // Determine the text and class based on the type
   let adText;
   let adClass;
-  let height;
+  let height = '';
   if (type === 'Advertisement') {
     adText = 'Advertisement';
     adClass = 'right-ad';
-    height = 'fixed-height';
+    if (fixedHeight) {
+      height = ' fixed-height';
+    }
   } else if (type === 'Sponsored post') {
     adText = 'Sponsored post';
     adClass = 'right-sponsored';
   } else {
     // eslint-disable-next-line no-console
     console.error('Unknown type in the block');
-    return;
+    return undefined;
   }
 
   // Build the ad using the extracted unit-id and determined text and class
   const rightAdHTML = `
     <!-- AD IMU  STARTS  -->
 
-    <div class="${adClass} ${height}">
+    <div class="${adClass}${height}">
       <span class="ad-title">${adText}</span> <br />
       <div id="${unitId}" class="tmsads"></div>
     </div>
@@ -985,5 +990,4 @@ export function commaSeparatedListContains(list, value) {
   return listStr.split(',')
     .map((item) => item.trim())
     .includes(value);
->>>>>>> main
 }

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -928,3 +928,43 @@ export function loadTemplateArticleCards(main, templateName, articles) {
     }
   });
 }
+
+/**
+ * Builds an ad block with the given ID and type.
+ * @param {string} unitId ID of the ad to include in the block.
+ * @param {string} type The type of ad to create.
+ * @returns {HTMLElement} Newly built ad block.
+ */
+export function buildAdBlock(unitId, type) {
+  // Determine the text and class based on the type
+  let adText;
+  let adClass;
+  let height;
+  if (type === 'Advertisement') {
+    adText = 'Advertisement';
+    adClass = 'right-ad';
+    height = 'fixed-height';
+  } else if (type === 'Sponsored post') {
+    adText = 'Sponsored post';
+    adClass = 'right-sponsored';
+  } else {
+    // eslint-disable-next-line no-console
+    console.error('Unknown type in the block');
+    return;
+  }
+
+  // Build the ad using the extracted unit-id and determined text and class
+  const rightAdHTML = `
+    <!-- AD IMU  STARTS  -->
+
+    <div class="${adClass} ${height}">
+      <span class="ad-title">${adText}</span> <br />
+      <div id="${unitId}" class="tmsads"></div>
+    </div>
+
+    <br clear="all">
+  `;
+
+  const range = document.createRange();
+  return range.createContextualFragment(rightAdHTML);
+}


### PR DESCRIPTION
Places ads within the `lead-article` variant of the `article-cards` block. One ad is placed below the featured article, and another below the sub-articles (but only when there is less than 5 sub-articles).

Fix #71 

Test URLs:
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/
- After: https://issue-71--channelco-crn-com--hlxsites.hlx.page/
- After: https://issue-71--channelco-crn-com--hlxsites.hlx.page/news/computing/
