### PR TITLE
fix: optimize home page and templates with head metadata.

### DIFF
--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -501,7 +501,8 @@ export async function getRecordsByPath(paths) {
     const pathUrl = `${window.location.protocol}//${window.location.host}${path}`;
     return getMetadataJson(pathUrl);
   });
-  return Promise.all(promises);
+  const results = await Promise.all(promises);
+  return results.filter((value) => !!value);
 }
 
 /**

--- a/templates/article/article.js
+++ b/templates/article/article.js
@@ -1,5 +1,5 @@
+import { getMetadata } from '../../scripts/lib-franklin.js';
 import {
-  getRecordByPath,
   getCategoryName,
   getCategoryPath,
   getAuthorByName,
@@ -30,7 +30,7 @@ export function loadEager(main) {
   buildSocialShare(picture);
 
   const categoryLink = document.createElement('a');
-  categoryLink.classList.add('link-arrow', 'article-category-link', 'placeholder');
+  categoryLink.classList.add('link-arrow', 'article-category-link');
   categoryLink.innerText = 'Category';
   heading.parentElement.insertBefore(categoryLink, heading);
 
@@ -46,10 +46,13 @@ export function loadEager(main) {
 // eslint-disable-next-line import/prefer-default-export
 export async function loadLazy(main) {
   const path = window.location.pathname;
-  const article = await getRecordByPath(path);
-  if (!article) {
-    return;
-  }
+  const article = {
+    path,
+    category: getMetadata('category'),
+    author: getMetadata('author'),
+    publisheddate: getMetadata('publisheddate'),
+    keywords: getMetadata('keywords'),
+  };
 
   const categoryPath = getCategoryPath(path);
   const categoryName = getCategoryName(article);

--- a/templates/article/article.js
+++ b/templates/article/article.js
@@ -11,6 +11,16 @@ import {
   getRelatedArticles,
 } from '../../scripts/shared.js';
 
+function getArticleByMetadata() {
+  return {
+    path: window.location.pathname,
+    category: getMetadata('category'),
+    author: getMetadata('author'),
+    publisheddate: getMetadata('publisheddate'),
+    keywords: getMetadata('keywords'),
+  };
+}
+
 /**
  * Processes the DOM as necessary in order to auto block items required
  * for all articles.
@@ -29,12 +39,20 @@ export function loadEager(main) {
 
   buildSocialShare(picture);
 
+  const article = getArticleByMetadata();
+
+  const categoryPath = getCategoryPath(article.path);
+  const categoryName = getCategoryName(article);
+
   const categoryLink = document.createElement('a');
   categoryLink.classList.add('link-arrow', 'article-category-link');
-  categoryLink.innerText = 'Category';
+  categoryLink.innerText = categoryName;
+  categoryLink.href = categoryPath;
+  categoryLink.title = categoryName;
+  categoryLink.ariaLabel = categoryName;
   heading.parentElement.insertBefore(categoryLink, heading);
 
-  const authorContainer = buildArticleAuthor();
+  const authorContainer = buildArticleAuthor(article);
   heading.parentElement.insertBefore(authorContainer, heading.nextSibling);
 }
 
@@ -45,33 +63,7 @@ export function loadEager(main) {
  */
 // eslint-disable-next-line import/prefer-default-export
 export async function loadLazy(main) {
-  const path = window.location.pathname;
-  const article = {
-    path,
-    category: getMetadata('category'),
-    author: getMetadata('author'),
-    publisheddate: getMetadata('publisheddate'),
-    keywords: getMetadata('keywords'),
-  };
-
-  const categoryPath = getCategoryPath(path);
-  const categoryName = getCategoryName(article);
-
-  const categoryPlaceholder = main.querySelector('.article .article-category-link');
-  if (categoryPlaceholder) {
-    const categoryLink = document.createElement('a');
-    categoryLink.classList.add('link-arrow', 'article-category-link');
-    categoryLink.innerText = categoryName;
-    categoryLink.href = categoryPath;
-    categoryLink.title = categoryName;
-    categoryLink.ariaLabel = categoryName;
-    categoryPlaceholder.replaceWith(categoryLink);
-  }
-
-  const authorPlaceholder = main.querySelector('.article .article-author-container');
-  if (authorPlaceholder) {
-    authorPlaceholder.replaceWith(buildArticleAuthor(article));
-  }
+  const article = getArticleByMetadata();
 
   const contentSection = main.querySelector('.content-section');
   if (!contentSection) {

--- a/templates/category/category.js
+++ b/templates/category/category.js
@@ -5,12 +5,12 @@ import {
 } from '../../scripts/lib-franklin.js';
 import {
   getArticlesByCategory,
-  getRecordByPath,
   comparePublishDate,
   buildArticleCardsBlock,
   buildNewsSlider,
   loadTemplateArticleCards,
   addToTopSection,
+  getTitle,
 } from '../../scripts/shared.js';
 
 /**
@@ -59,7 +59,8 @@ function createHeading(text, ...classes) {
  */
 // eslint-disable-next-line import/prefer-default-export
 export function loadEager(main) {
-  addToTopSection(main, createHeading('Category', 'placeholder'));
+  const title = getTitle();
+  addToTopSection(main, createHeading(title));
   buildNewsSlider(main);
 
   let lastElement;
@@ -76,7 +77,7 @@ export function loadEager(main) {
     firstSection.insertBefore(leadCards, lastElement);
   });
 
-  const newsHeading = createNewsHeading('Category News', 'placeholder');
+  const newsHeading = createNewsHeading(`${title} News`);
   firstSection.insertBefore(newsHeading, lastElement);
 
   buildArticleCardsBlock(8, 'category', (cards) => {
@@ -90,26 +91,12 @@ export function loadEager(main) {
  */
 // eslint-disable-next-line import/prefer-default-export
 export async function loadLazy(main) {
-  const category = await getRecordByPath(window.location.pathname);
-  if (!category) {
-    return;
-  }
   const contentSection = main.querySelector('.content-section');
   if (!contentSection) {
     return;
   }
 
-  const heading = main.querySelector('.category h1');
-  if (heading) {
-    heading.replaceWith(createHeading(category.title));
-  }
-
-  const newsHeading = main.querySelector('.category .news-heading');
-  if (newsHeading) {
-    newsHeading.replaceWith(createNewsHeading(`${category.title} News`));
-  }
-
-  const articles = await getArticlesByCategory(category.title);
+  const articles = await getArticlesByCategory(getTitle());
   articles.sort(comparePublishDate);
 
   loadTemplateArticleCards(main, 'category', articles);

--- a/templates/company/company.js
+++ b/templates/company/company.js
@@ -1,5 +1,5 @@
 import {
-  getRecordByPath,
+  getTitle,
   comparePublishDate,
   queryIndex,
   isArticle,
@@ -18,6 +18,7 @@ export function loadEager(main) {
     return;
   }
 
+  const companyName = getTitle();
   buildArticleCardsBlock(8, 'company', (cards) => { firstSection.prepend(cards); });
 
   const h2 = document.createElement('h2');
@@ -31,8 +32,8 @@ export function loadEager(main) {
   });
 
   const h1 = document.createElement('h1');
-  h1.innerText = 'Company';
-  h1.classList.add('company-heading', 'placeholder');
+  h1.innerText = companyName;
+  h1.classList.add('company-heading');
   firstSection.prepend(h1);
 }
 
@@ -41,18 +42,8 @@ export function loadEager(main) {
  * @param {HTMLElement} main The page's main element.
  */
 export async function loadLazy(main) {
-  const company = await getRecordByPath(window.location.pathname);
-  if (!company) {
-    return;
-  }
+  const companyName = getTitle();
 
-  const companyName = company.companynames;
-  const heading = main.querySelector('.company-heading');
-  if (heading) {
-    const newHeading = document.createElement('h1');
-    newHeading.innerText = companyName;
-    heading.replaceWith(newHeading);
-  }
   const articles = await queryIndex((record) => isArticle(record)
     && commaSeparatedListContains(record.companynames, companyName));
   articles.sort(comparePublishDate);

--- a/templates/tag/tag.js
+++ b/templates/tag/tag.js
@@ -4,13 +4,13 @@ import {
   loadBlock,
 } from '../../scripts/lib-franklin.js';
 import {
-  getRecordByPath,
   buildArticleCardsBlock,
   commaSeparatedListContains,
   queryIndex,
   isArticle,
   comparePublishDate,
   loadTemplateArticleCards,
+  getKeywords,
 } from '../../scripts/shared.js';
 
 /**
@@ -26,8 +26,8 @@ export function loadEager(main) {
   buildArticleCardsBlock(10, 'tag', (cards) => { firstSection.prepend(cards); });
 
   const title = document.createElement('h1');
-  title.innerText = 'Keyword';
-  title.classList.add('tag-title', 'placeholder');
+  title.innerText = getKeywords();
+  title.classList.add('tag-title');
   firstSection.prepend(title);
 }
 
@@ -36,18 +36,7 @@ export function loadEager(main) {
  * @param {HTMLElement} main The page's main element.
  */
 export async function loadLazy(main) {
-  const tag = await getRecordByPath(window.location.pathname);
-  if (!tag) {
-    return;
-  }
-
-  const tagName = tag.keywords;
-  const heading = main.querySelector('.tag-title');
-  if (heading) {
-    const tagHeading = document.createElement('h1');
-    tagHeading.innerText = tagName;
-    heading.replaceWith(tagHeading);
-  }
+  const tagName = getKeywords();
 
   const records = await queryIndex((record) => isArticle(record)
     && commaSeparatedListContains(record.keywords, tagName));


### PR DESCRIPTION
Optimizes the home page and most templates by relying more on the page's metadata. The home page will request each URL in the article cards block, and use the `<head>` metadata from each page to populate the cards instead of querying the index.

The templates will pull more data from the page `<head>` metadata instead of querying the index for the same information.

This will also fix the blank card information currently displayed on most pages.

Test URLs:
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/
- After: https://homepage-optimization--channelco-crn-com--hlxsites.hlx.page/
- After: https://homepage-optimization--channelco-crn-com--hlxsites.hlx.page/news/components-peripherals/
- After: https://homepage-optimization--channelco-crn-com--hlxsites.hlx.page/tag/Notebooks/
- After: https://homepage-optimization--channelco-crn-com--hlxsites.hlx.page/news/managed-services/painful-decision-slalom-consulting-layoffs-hit-900-workers
