### PR TITLE
fix: show formatted dates in article cards.

### DIFF
--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -724,6 +724,31 @@ export function getRecordsFromBlock(block) {
 }
 
 /**
+ * Checks whether a given value appears to be a timestamp, and if so converts it
+ * into a formatted date string. Otherwise the method will return the original
+ * value as-is.
+ * @param {string} dateValue Potential date value to format.
+ * @returns {string} Formatted date, or the original value.
+ */
+export function formatDate(dateValue) {
+  if (/^[0-9]+$/g.test(dateValue)) {
+    const publishDate = new Date(parseInt(dateValue, 10) * 1000);
+    const dateStr = publishDate.toLocaleDateString('en-us', {
+      month: 'long',
+      day: '2-digit',
+      year: 'numeric',
+    });
+    const timeStr = publishDate.toLocaleTimeString('en-us', {
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZoneName: 'short',
+    });
+    return `${dateStr}, ${timeStr}`;
+  }
+  return dateValue;
+}
+
+/**
  * Creates an HTML element that contains an article author's name, a link to the
  * author's profile page, and the publish date of the article. If an article
  * is not provided, the method will create placeholders.
@@ -750,7 +775,7 @@ export function buildArticleAuthor(article) {
       <a href="/authors/${authorId}" class="link-arrow" aria-label="By ${article.author}"><span class="uncolored-link">By</span> ${article.author}</a>
     `;
 
-    date.innerText = article.publisheddate;
+    date.innerText = formatDate(article.publisheddate);
   } else {
     author.classList.add('placeholder');
     date.classList.add('placeholder');


### PR DESCRIPTION
This was actually a problem on all templates except for the home page. Added a function that will check to see if the date is a number, and format it correctly if so.

Fix #128 

Test URLs:
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/search?query=oracle
- After: https://issue-128--channelco-crn-com--hlxsites.hlx.page/search?query=oracle
