### PR TITLE
feat: link learn more block to search page.

### DIFF
--- a/blocks/tag/tag.css
+++ b/blocks/tag/tag.css
@@ -1,1 +1,0 @@
-/* styles here */

--- a/blocks/tag/tag.js
+++ b/blocks/tag/tag.js
@@ -1,3 +1,0 @@
-export default function decorate(block) {
-  block.innerHTML = 'tag placeholder';
-}

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -902,7 +902,7 @@ export async function buildLearnMore(target, keywords) {
   items.forEach((keyword) => {
     const li = document.createElement('li');
     li.innerHTML = `
-      <a href="/tag/${encodeURIComponent(keyword)}/" title="${keyword}" aria-label="${keyword}">
+      <a href="/search?query=${encodeURIComponent(keyword)}" title="${keyword}" aria-label="${keyword}">
         ${keyword}
       </a>
     `;

--- a/templates/search-results/search-results.js
+++ b/templates/search-results/search-results.js
@@ -139,9 +139,7 @@ export async function loadLazy(main) {
   if (searchTerm) {
     const searchCompare = searchTerm.toLowerCase();
     const words = searchCompare.split(' ').filter((value) => !!value);
-    const entries = queryIndex((record) => recordContainsWords(record, words),
-      500,
-    )
+    const entries = queryIndex((record) => recordContainsWords(record, words), 500)
       .sheet('article');
 
     // eslint-disable-next-line no-restricted-syntax

--- a/templates/search-results/search-results.js
+++ b/templates/search-results/search-results.js
@@ -38,6 +38,36 @@ function getSearchTerm() {
 }
 
 /**
+ * Determines whether a given string is related to a list of words.
+ * @param {string} toSearch Value to check.
+ * @param {Array<string>} words Words to match.
+ * @returns {boolean} True if the value relates to the words.
+ */
+function containsWords(toSearch, words) {
+  const value = String(toSearch);
+  for (let i = 0; i < words.length; i += 1) {
+    if (value.includes(words[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Determines whether a record from the index is related to a list of words.
+ * @param {import('../../scripts/shared.js').QueryIndexRecord} record Index
+ *  record to check.
+ * @param {Array<string>} words Words to match.
+ * @returns {boolean} True if the record relates to the words.
+ */
+function recordContainsWords(record, words) {
+  if (containsWords(record.title, words)) {
+    return true;
+  }
+  return containsWords(record.description, words);
+}
+
+/**
  * Modifies the DOM as needed for search results
  * @param {HTMLElement} main The page's main element.
  */
@@ -108,9 +138,8 @@ export async function loadLazy(main) {
   const results = [];
   if (searchTerm) {
     const searchCompare = searchTerm.toLowerCase();
-    const entries = queryIndex(
-      (record) => (String(record.title).toLowerCase().includes(searchCompare)
-      || String(record.description).toLowerCase().includes(searchCompare)),
+    const words = searchCompare.split(' ').filter((value) => !!value);
+    const entries = queryIndex((record) => recordContainsWords(record, words),
       500,
     )
       .sheet('article');


### PR DESCRIPTION
Changes the following:

* Links in the "Learn More" block will now go to the search page, with the clicked keyword as the pre-loaded search string.
* Removed the `tags` template.
* Change the search page so that it will match articles that contain _any_ of the words in the search term.

@kunwarsaluja I wanted to give a quick overview of how search works.

Generally, it only searches based on an article's `title` or `description` (since that's all we have available in the index). Matching is _not_ case sensitive. Before this change, searching for "computer accessories" would only match articles whose title or description contained the full phrase "computer accessories". After this change, it will match articles whose title or description contains either of the words "computer" or "accessories".

Another aspect is that we're only searching through the most recent 1,500 articles. This is for performance reasons, since the more articles we search through, the longer a search will take. We can play with the maximum number of articles we search, but with the current search implementation we'll have some limit on the number of articles we can search.

I saw in the video that someone tried surrounding the search with quotes. This is currently _not_ supported, and would require some fairly complex parsing to support. We could certainly add it, but it's not there today.

Fix #136 

Test URLs:
- Before: https://main--channelco-crn-com--hlxsites.hlx.page/news/managed-services/painful-decision-slalom-consulting-layoffs-hit-900-workers
- After: https://issue-136--channelco-crn-com--hlxsites.hlx.page/news/managed-services/painful-decision-slalom-consulting-layoffs-hit-900-workers
